### PR TITLE
Add typing-extensions to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "requests",
+        "typing-extensions",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
When I try to install import and run exa-py in a venv on a python 3.10.5 version, I get a "no module named typing-extensions" error. It's not included in the setup.py install_requires, but the package uses a lot of types. 

This PR is a one line change to add typing-extensions to install requires.