### PR TITLE
Update sdk to include search filters

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -426,7 +426,7 @@ class Exa:
                 data["autopromptString"] if "autopromptString" in data else None
             ),
             filters=SearchFilters(
-                **to_snake_case(data["filters"]) if "filters" in data else None
+                **to_snake_case(data["filters"]) if "filters" in data else {}
             ),
         )
 
@@ -522,7 +522,7 @@ class Exa:
                 data["autopromptString"] if "autopromptString" in data else None
             ),
             filters=SearchFilters(
-                **to_snake_case(data["filters"]) if "filters" in data else None
+                **to_snake_case(data["filters"]) if "filters" in data else {}
             ),
         )
 
@@ -574,7 +574,7 @@ class Exa:
                 data["autopromptString"] if "autopromptString" in data else None
             ),
             filters=SearchFilters(
-                **to_snake_case(data["filters"]) if "filters" in data else None
+                **to_snake_case(data["filters"]) if "filters" in data else {}
             ),
         )
 
@@ -602,7 +602,7 @@ class Exa:
                 data["autopromptString"] if "autopromptString" in data else None
             ),
             filters=SearchFilters(
-                **to_snake_case(data["filters"]) if "filters" in data else None
+                **to_snake_case(data["filters"]) if "filters" in data else {}
             ),
         )
 
@@ -694,6 +694,6 @@ class Exa:
                 data["autopromptString"] if "autopromptString" in data else None
             ),
             filters=SearchFilters(
-                **to_snake_case(data["filters"]) if "filters" in data else None
+                **(to_snake_case(data["filters"]) if "filters" in data else {})
             ),
         )


### PR DESCRIPTION
Now that we infer search filters from autoprompt, this updates the sdk to return those search filters to the user.

I chose to return all the filters, not just the auto prompted ones, to match the behavior of the API.

It won't throw an error on old versions of API, filters will just be {}