### PR TITLE
Don't manually define openai kwargs to reduce surface area we have to keep consistent with openai

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -20,17 +20,8 @@ from typing_extensions import TypedDict
 
 import httpx
 from openai import NOT_GIVEN, NotGiven, OpenAI
-from openai.types.chat.chat_completion_stream_options_param import (
-    ChatCompletionStreamOptionsParam,
-)
 from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
 from openai.types.chat_model import ChatModel
-from openai.types.chat.chat_completion_tool_choice_option_param import (
-    ChatCompletionToolChoiceOptionParam,
-)
-from openai.types.chat.chat_completion_tool_param import ChatCompletionToolParam
-from openai._types import Headers, Query, Body
-from openai.types.chat import completion_create_params
 from exa_py.utils import (
     ExaOpenAICompletion,
     add_message_to_messages,
@@ -692,38 +683,6 @@ class Exa:
             # Mandatory OpenAI args
             messages: Iterable[ChatCompletionMessageParam],
             model: Union[str, ChatModel],
-            # Optional OpenAI args
-            frequency_penalty: Optional[float] | NotGiven = NOT_GIVEN,
-            function_call: completion_create_params.FunctionCall | NotGiven = NOT_GIVEN,
-            functions: (
-                Iterable[completion_create_params.Function] | NotGiven
-            ) = NOT_GIVEN,
-            logit_bias: Optional[Dict[str, int]] | NotGiven = NOT_GIVEN,
-            logprobs: Optional[bool] | NotGiven = NOT_GIVEN,
-            max_tokens: Optional[int] | NotGiven = NOT_GIVEN,
-            n: Optional[int] | NotGiven = NOT_GIVEN,
-            presence_penalty: Optional[float] | NotGiven = NOT_GIVEN,
-            response_format: (
-                completion_create_params.ResponseFormat | NotGiven
-            ) = NOT_GIVEN,
-            seed: Optional[int] | NotGiven = NOT_GIVEN,
-            stop: Union[Optional[str], List[str]] | NotGiven = NOT_GIVEN,
-            stream: Optional[Literal[False]] | NotGiven = NOT_GIVEN,
-            stream_options: (
-                Optional[ChatCompletionStreamOptionsParam] | NotGiven
-            ) = NOT_GIVEN,
-            temperature: Optional[float] | NotGiven = NOT_GIVEN,
-            tool_choice: ChatCompletionToolChoiceOptionParam | NotGiven = NOT_GIVEN,
-            tools: Iterable[ChatCompletionToolParam] | NotGiven = NOT_GIVEN,
-            top_logprobs: Optional[int] | NotGiven = NOT_GIVEN,
-            top_p: Optional[float] | NotGiven = NOT_GIVEN,
-            user: str | NotGiven = NOT_GIVEN,
-            # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
-            # The extra values given here take precedence over values defined on the client or passed to this method.
-            extra_headers: Headers | None = None,
-            extra_query: Query | None = None,
-            extra_body: Body | None = None,
-            timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
             # Exa args
             use_exa: Optional[Literal["required", "none", "auto"]] = "auto",
             highlights: Union[HighlightsContentsOptions, Literal[True], None] = None,
@@ -738,6 +697,8 @@ class Exa:
             type: Optional[str] = None,
             category: Optional[str] = None,
             result_max_len: int = 2048,
+            # OpenAI args
+            **openai_kwargs,
         ):
             exa_kwargs = {
                 "num_results": num_results,
@@ -755,33 +716,11 @@ class Exa:
 
             create_kwargs = {
                 "model": model,
-                "frequency_penalty": frequency_penalty,
-                "function_call": function_call,
-                "functions": functions,
-                "logit_bias": logit_bias,
-                "logprobs": logprobs,
-                "max_tokens": max_tokens,
-                "n": n,
-                "presence_penalty": presence_penalty,
-                "response_format": response_format,
-                "seed": seed,
-                "stop": stop,
-                "stream": stream,
-                "stream_options": stream_options,
-                "temperature": temperature,
-                "tool_choice": tool_choice,
-                "tools": tools,
-                "top_logprobs": top_logprobs,
-                "top_p": top_p,
-                "user": user,
-                "extra_headers": extra_headers,
-                "extra_query": extra_query,
-                "extra_body": extra_body,
-                "timeout": timeout,
+                **openai_kwargs,
             }
 
             if use_exa != "none":
-                assert tools is NOT_GIVEN, "Tool use is not supported with Exa"
+                assert "tools" not in create_kwargs, "Tool use is not supported with Exa"
                 create_kwargs["tool_choice"] = use_exa
 
             return self._create_with_tool(

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,6 @@ setup(
         "typing-extensions",
         "openai"
     ],
-    extras_require={
-        "openai": ["openai"]
-    },
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Two problems popped up
1. If the user already had an old version of openai installed, because openai was in extras_require the code would work but error because of a version conflict
2. In general, because I was explicitly typing all the openai args it was too dependent on specific args that could change too much between versions

In this PR I moved openai to required and also just have a catchall, untyped **openai_kwargs as the openai parameters. We lose typing info but this is probably the least bad solution.

In general this still doesn't support arbitrary openai versions, which isn't great but this is at least a simple fix.