### PR TITLE
Remove uneeded dependencies and pin openai version

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -19,7 +19,7 @@ from typing import (
 from typing_extensions import TypedDict
 
 import httpx
-from openai import NOT_GIVEN, NotGiven, OpenAI
+from openai import OpenAI
 from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
 from openai.types.chat_model import ChatModel
 from exa_py.utils import (

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         "requests",
         "typing-extensions",
-        "openai"
+        "openai>=1.10.0"
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
In response to a user error -- they were running an old version of openai. This fixes that by pinning the version, and also removes the uneeded NOT_GIVEN dependency that caused the error.