### PR TITLE
Ensure compatibility with Python 3.11 and above

### DIFF
--- a/exa_py/utils.py
+++ b/exa_py/utils.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 
-def maybe_get_query(completion) -> str | None:
+def maybe_get_query(completion):
     """Extract query from completion if it exists."""
     if completion.choices[0].message.tool_calls:
         for tool_call in completion.choices[0].message.tool_calls:

--- a/exa_py/utils.py
+++ b/exa_py/utils.py
@@ -8,7 +8,9 @@ if TYPE_CHECKING:
 
 
 
-def maybe_get_query(completion):
+from typing import Union
+
+def maybe_get_query(completion) -> Union[str, None]:
     """Extract query from completion if it exists."""
     if completion.choices[0].message.tool_calls:
         for tool_call in completion.choices[0].message.tool_calls:

--- a/exa_py/utils.py
+++ b/exa_py/utils.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional
+from typing import Optional, Union
 from openai.types.chat import ChatCompletion
 
 from typing import TYPE_CHECKING 
@@ -7,8 +7,6 @@ if TYPE_CHECKING:
     from exa_py.api import ResultWithText, SearchResponse
 
 
-
-from typing import Union
 
 def maybe_get_query(completion) -> Union[str, None]:
     """Extract query from completion if it exists."""


### PR DESCRIPTION
-> str | None is no longer supported by Python 3.11 and above

-> Union[str, None] is better for union types and is compatible with later and older version of Python.