### PR TITLE
Update setup.py: openai>=1.20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         "requests",
         "typing-extensions",
-        "openai>=1.10.0"
+        "openai>=1.20.0"
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Latest `exa-py` version uses `from openai.types.chat_model import ChatModel`. However, it does not exist in `openai<1.20`. Given the following code:
```
from exa_py import Exa

if __name__ == '__main__':
    exa = Exa(api_key="ok")
```

1. It fails with
```
exa-py==1.0.12
openai==1.19
```
Producing this error:
```
from openai.types.chat_model import ChatModel
ModuleNotFoundError: No module named 'openai.types.chat_model'
```

2. It works with
```
exa-py==1.0.12
openai==1.20
```

See [diff](https://github.com/openai/openai-python/compare/v1.19.0...v1.20.0) between openai 1.19 version and 1.20 version.