### PR TITLE
Determine sdk release procedure

### DIFF
--- a/.github/workflows/publish_on_tag.yml
+++ b/.github/workflows/publish_on_tag.yml
@@ -1,0 +1,76 @@
+name: Publish to PyPI on Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+      - '*.*.*'
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    env:
+      # Expect a PyPI token secret at repo settings: PYPI_API_TOKEN
+      TWINE_USERNAME: __token__
+      TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: |
+          # github.ref_name is just the tag name in push tag events
+          RAW_TAG="${GITHUB_REF_NAME}"
+          # Strip a leading 'v' if present (e.g., v1.2.3 -> 1.2.3)
+          VERSION="${RAW_TAG#v}"
+          echo "Derived version: $VERSION"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(.*)?$ ]]; then
+            echo "Tag '$RAW_TAG' does not look like a version. Refusing to publish." >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine wheel setuptools
+
+      - name: Update versions in pyproject.toml and setup.py
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.version.outputs.version }}'
+
+          echo "Updating pyproject.toml to version $VERSION"
+          # Update the [project] version line
+          sed -i -E "s/^version = \"[^\"]+\"/version = \"${VERSION}\"/" pyproject.toml
+
+          echo "Updating setup.py to version $VERSION"
+          sed -i -E "s/version=\"[^\"]+\"/version=\"${VERSION}\"/" setup.py
+
+          echo "Resulting versions:"
+          grep -n "^version\s*=\s*\"" pyproject.toml || true
+          grep -n "version=\"" setup.py || true
+
+      - name: Build sdist and wheel (setup.py)
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish to PyPI via Twine
+        env:
+          TWINE_USERNAME: ${{ env.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ env.TWINE_PASSWORD }}
+        run: |
+          twine upload dist/*
+
+      - name: Show uploaded files
+        run: ls -alh dist


### PR DESCRIPTION
Add GitHub Actions workflow to automate PyPI publishing on tag pushes.

---
[Slack Thread](https://exa-labs-inc.slack.com/archives/C090Z3VH487/p1754668703905649?thread_ts=1754668703.905649&cid=C090Z3VH487)

<a href="https://cursor.com/background-agent?bcId=bc-60fdbd37-b088-4faa-9761-f8afe477be2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60fdbd37-b088-4faa-9761-f8afe477be2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

