### PR TITLE
support trio async event loop via anyio

### DIFF
--- a/exa_py/websets/async_client.py
+++ b/exa_py/websets/async_client.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 from typing import List, Optional, Literal, Dict, Any, Union
+
+import anyio
 
 from .types import (
     Webset,
@@ -141,13 +142,12 @@ class AsyncWebsetsClient(WebsetsAsyncBaseClient):
         Raises:
             TimeoutError: If the webset does not become idle within the timeout period.
         """
-        start_time = asyncio.get_event_loop().time()
-        while True:
-            webset = await self.get(id)
-            if webset.status == WebsetStatus.idle.value:
-                return webset
-                
-            if asyncio.get_event_loop().time() - start_time > timeout:
-                raise TimeoutError(f"Webset {id} did not become idle within {timeout} seconds")
-                
-            await asyncio.sleep(poll_interval)
+        try:
+            with anyio.fail_after(timeout):
+                while True:
+                    webset = await self.get(id)
+                    if webset.status == WebsetStatus.idle.value:
+                        return webset
+                    await anyio.sleep(poll_interval)
+        except TimeoutError:
+            raise TimeoutError(f"Webset {id} did not become idle within {timeout} seconds")

--- a/exa_py/websets/core/async_base.py
+++ b/exa_py/websets/core/async_base.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import json
-import asyncio
 from typing import Any, Dict, Optional, Type, TypeVar, Union
 
 from .base import ExaBaseModel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "openai>=1.48",
     "pydantic>=2.10.6",
     "httpx>=0.28.1",
+    "anyio",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
This PR migrates away from direct `asyncio` usage in favour of AnyIO.  

The advantages of this include support for using exa-py with `trio` or `curio`, and more reliable structured concurrency.

Additional notes:
- Explicitly added `anyio` to `pyproject.toml` for clarity, though it was already an indirect dependency via `httpx`. The lack of a pinned version matches their `pyproject.toml` in order to not impose any extra restrictions on dependency resolution.
- All unit tests pass with the exception of the known failing test tracked in issue #118, and all external interfaces are identical.
