### PR TITLE
Add cost_dollars field to AnswerResponse and StreamAnswerResponse

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -640,14 +640,16 @@ class StreamChunk:
     Attributes:
         content (Optional[str]): The partial text content of the answer
         citations (Optional[List[AnswerResult]]): List of citations if provided in this chunk
+        cost_dollars (CostDollars, optional): Cost breakdown (typically in final chunk).
     """
 
     content: Optional[str] = None
     citations: Optional[List[AnswerResult]] = None
+    cost_dollars: Optional[CostDollars] = None
 
     def has_data(self) -> bool:
         """Check if this chunk contains any data."""
-        return self.content is not None or self.citations is not None
+        return self.content is not None or self.citations is not None or self.cost_dollars is not None
 
     def __str__(self) -> str:
         """Format the chunk data as a string."""
@@ -658,6 +660,12 @@ class StreamChunk:
             output += "\nCitations:"
             for source in self.citations:
                 output += f"\n{source}"
+        if self.cost_dollars:
+            output += f"\nCostDollars: total={self.cost_dollars.total}"
+            if self.cost_dollars.search:
+                output += f"\n  - search: {self.cost_dollars.search}"
+            if self.cost_dollars.contents:
+                output += f"\n  - contents: {self.cost_dollars.contents}"
         return output
 
 
@@ -668,10 +676,12 @@ class AnswerResponse:
     Attributes:
         answer (str): The generated answer.
         citations (List[AnswerResult]): A list of citations used to generate the answer.
+        cost_dollars (CostDollars, optional): Cost breakdown.
     """
 
     answer: Union[str, dict[str, Any]]
     citations: List[AnswerResult]
+    cost_dollars: Optional[CostDollars] = None
 
     def __str__(self):
         output = f"Answer: {self.answer}\n\nCitations:"
@@ -683,6 +693,12 @@ class AnswerResponse:
             output += f"\nAuthor: {source.author}"
             output += f"\nText: {source.text}"
             output += "\n"
+        if self.cost_dollars:
+            output += f"\nCostDollars: total={self.cost_dollars.total}"
+            if self.cost_dollars.search:
+                output += f"\n  - search: {self.cost_dollars.search}"
+            if self.cost_dollars.contents:
+                output += f"\n  - contents: {self.cost_dollars.contents}"
         return output
 
 
@@ -735,7 +751,9 @@ class StreamAnswerResponse:
                         )
                     )
 
-            stream_chunk = StreamChunk(content=content, citations=citations)
+            cost_dollars = parse_cost_dollars(chunk.get("costDollars"))
+
+            stream_chunk = StreamChunk(content=content, citations=citations, cost_dollars=cost_dollars)
             if stream_chunk.has_data():
                 yield stream_chunk
 
@@ -794,7 +812,9 @@ class AsyncStreamAnswerResponse:
                             )
                         )
 
-                stream_chunk = StreamChunk(content=content, citations=citations)
+                cost_dollars = parse_cost_dollars(chunk.get("costDollars"))
+
+                stream_chunk = StreamChunk(content=content, citations=citations, cost_dollars=cost_dollars)
                 if stream_chunk.has_data():
                     yield stream_chunk
 
@@ -1789,7 +1809,8 @@ class Exa:
                     text=snake_result.get("text"),
                 )
             )
-        return AnswerResponse(response["answer"], citations)
+        cost_dollars = parse_cost_dollars(response.get("costDollars"))
+        return AnswerResponse(response["answer"], citations, cost_dollars=cost_dollars)
 
     def stream_answer(
         self,
@@ -2367,7 +2388,8 @@ class AsyncExa(Exa):
                     text=snake_result.get("text"),
                 )
             )
-        return AnswerResponse(response["answer"], citations)
+        cost_dollars = parse_cost_dollars(response.get("costDollars"))
+        return AnswerResponse(response["answer"], citations, cost_dollars=cost_dollars)
 
     async def stream_answer(
         self,


### PR DESCRIPTION
# Add cost_dollars field to AnswerResponse and StreamAnswerResponse

## Summary
Fixes #134 - The API returns `costDollars` in answer responses, but the SDK was not exposing this field.

This PR adds the `cost_dollars` field to:
- `AnswerResponse` dataclass
- `StreamChunk` dataclass (for streaming responses)

The implementation follows the existing pattern used by `SearchResponse` for handling `cost_dollars`, reusing the existing `parse_cost_dollars()` helper function.

## Review & Testing Checklist for Human
- [ ] **Verify API response structure**: Confirm that the `/answer` endpoint actually returns `costDollars` with the expected structure (total, search, contents breakdown). The `CostDollars` type was designed for search responses - verify it matches answer responses.
- [ ] **Test streaming responses**: Verify that `costDollars` is included in streaming chunks (typically the final chunk). I couldn't test this against the live API.
- [ ] **Test with live API**: Run a simple test like:
  ```python
  from exa_py import Exa
  exa = Exa(api_key="...")
  response = exa.answer("What is Python?")
  print(response.cost_dollars)  # Should show cost breakdown
  ```

### Notes
- All 109 unit tests pass
- The implementation mirrors how `SearchResponse` handles `cost_dollars`
- Link to Devin run: https://app.devin.ai/sessions/6523d6fb5b9d42368aa4b1bbe31f6f19
- Requested by: Felix Zeller (felix@exa.ai) / @Feel-ix-343