### PR TITLE
[exa-py]: fix Result.__str__ to handle optional text/summary fields

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -472,7 +472,11 @@ class Result(_Result):
 
     def __str__(self):
         base_str = super().__str__()
-        result = base_str + f"Text: {self.text}\nSummary: {self.summary}\n"
+        result = base_str
+        if self.text is not None:
+            result += f"Text: {self.text}\n"
+        if self.summary is not None:
+            result += f"Summary: {self.summary}\n"
         if self.highlights:
             result += f"Highlights: {self.highlights}\n"
         if self.highlight_scores:


### PR DESCRIPTION
## Summary

Fixes `Result.__str__` to only include `text` and `summary` fields when they are not None, matching the behavior of `highlights` and `highlight_scores` which already have conditional checks.

Previously, the `__str__` method always appended `Text: None` and `Summary: None` even when these optional fields weren't requested/returned. This was inconsistent with the type annotations (`Optional[str]`) and with how exa-js/Vulcan handle these fields (both are optional in the API response schema).

## Review & Testing Checklist for Human

- [ ] Verify the behavior difference between `None` (field absent) vs `""` (empty string) is acceptable - this PR uses `is not None` so empty strings will still be printed
- [ ] Quick sanity check: run `str(Result(url="x", id="y"))` and confirm no `Text:` or `Summary:` lines appear

### Notes

- Verified parity with exa-js SDK where `text` and `summary` come from `ContentsResultComponent` and are conditionally added
- Verified Vulcan types show `text: z.string().optional()` and `summary: z.string().optional()`
- Unit tests pass locally

Link to Devin run: https://app.devin.ai/sessions/e66881e28a914d1bae92943ed2f358f2
Requested by: Miguel Brandão (@MiguelAtExa)