### PR TITLE
[sdk]: Increase default max_characters from 10,000 to 20,000

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -48,7 +48,7 @@ from .research import ResearchClient, AsyncResearchClient
 is_beta = os.getenv("IS_BETA") == "True"
 
 # Default max characters for text contents
-DEFAULT_MAX_CHARACTERS = 10_000
+DEFAULT_MAX_CHARACTERS = 20_000
 
 
 def snake_to_camel(snake_str: str) -> str:

--- a/tests/integration/test_find_similar_integration.py
+++ b/tests/integration/test_find_similar_integration.py
@@ -8,15 +8,15 @@ class TestFindSimilarContentsOptions:
 
     TEST_URL = "https://en.wikipedia.org/wiki/Ant"
 
-    def test_defaults_to_text_contents_with_10k_max_characters(self, exa):
-        """Verify find_similar() returns text contents with 10,000 max chars by default."""
+    def test_defaults_to_text_contents_with_20k_max_characters(self, exa):
+        """Verify find_similar() returns text contents with 20,000 max chars by default."""
         response = exa.find_similar(self.TEST_URL, num_results=2)
 
         assert len(response.results) > 0
         sample_result = response.results[0]
         assert sample_result.text is not None
         assert len(sample_result.text) > 1000
-        assert len(sample_result.text) <= 10_000
+        assert len(sample_result.text) <= 20_000
 
     def test_returns_no_contents_when_explicitly_false(self, exa):
         """Verify find_similar() returns no contents when contents=False."""
@@ -108,7 +108,7 @@ class TestAsyncFindSimilarContentsOptions:
         sample_result = response.results[0]
         assert sample_result.text is not None
         assert len(sample_result.text) > 1000
-        assert len(sample_result.text) <= 10_000
+        assert len(sample_result.text) <= 20_000
 
     async def test_async_returns_no_contents_when_false(self, async_exa):
         """Verify async find_similar() returns no contents when contents=False."""

--- a/tests/integration/test_search_integration.py
+++ b/tests/integration/test_search_integration.py
@@ -8,15 +8,15 @@ class TestSearchContentsOptions:
 
     TEST_QUERY = "invasive ant species California"
 
-    def test_defaults_to_text_contents_with_10k_max_characters(self, exa):
-        """Verify search() returns text contents with 10,000 max chars by default."""
+    def test_defaults_to_text_contents_with_20k_max_characters(self, exa):
+        """Verify search() returns text contents with 20,000 max chars by default."""
         response = exa.search(self.TEST_QUERY, num_results=2)
 
         assert len(response.results) > 0
         sample_result = response.results[0]
         assert sample_result.text is not None
         assert len(sample_result.text) > 1000
-        assert len(sample_result.text) <= 10_000
+        assert len(sample_result.text) <= 20_000
 
     def test_returns_no_contents_when_explicitly_false(self, exa):
         """Verify search() returns no contents when contents=False."""
@@ -104,7 +104,7 @@ class TestAsyncSearchContentsOptions:
         sample_result = response.results[0]
         assert sample_result.text is not None
         assert len(sample_result.text) > 1000
-        assert len(sample_result.text) <= 10_000
+        assert len(sample_result.text) <= 20_000
 
     async def test_async_returns_no_contents_when_false(self, async_exa):
         """Verify async search() returns no contents when contents=False."""


### PR DESCRIPTION
## Summary
Increases the `DEFAULT_MAX_CHARACTERS` constant from 10,000 to 20,000. This constant is used as the default value for `max_characters` when retrieving text contents via search, find_similar, and get_contents methods.

Integration tests were updated to reflect the new default value.

## Review & Testing Checklist for Human
- [ ] Confirm 20,000 is the intended new default value
- [ ] Check if any documentation (README, docstrings) references the old 10,000 default that should be updated

### Notes
- Link to Devin run: https://app.devin.ai/sessions/d5950a8ade014b809a64a8547ae364d5
- Requested by: Sol Kim (@Dynosol)