### PR TITLE
[exa-py]: sync setup.py version to 2.2.0 for PyPI publish

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.1.1",
+    version="2.2.0",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),


### PR DESCRIPTION
## Summary

Syncs `setup.py` version from 2.1.1 to 2.2.0 to match `pyproject.toml`. This is needed so that when the package is published to PyPI, the updated README (which removes deprecated `search_and_contents` examples) will be visible on the PyPI page.

The README was already updated in PR #158 to use the current API patterns (`search()` with `contents=` parameter instead of `search_and_contents()`), but PyPI still shows the old examples because version 2.2.0 hasn't been published yet.

## Review & Testing Checklist for Human

- [ ] After merging, run `./publish.sh` to publish 2.2.0 to PyPI
- [ ] Verify the PyPI page at https://pypi.org/project/exa-py/ shows the updated README without `search_and_contents` examples

### Notes

- Linear ticket: [MDL-291](https://linear.app/exalabs/issue/MDL-291)
- Link to Devin run: https://app.devin.ai/sessions/9f97026105774930b2a4b22a683388c1
- Requested by: Aman Choudhri (@amanchoudhri)