### PR TITLE
Add `pending` status in `WebsetStatus` and `WebsetSearchStatus` enum

### DIFF
--- a/exa_py/websets/types.py
+++ b/exa_py/websets/types.py
@@ -1915,6 +1915,7 @@ class WebsetSearchStatus(Enum):
     """
 
     created = 'created'
+    pending = 'pending'
     running = 'running'
     completed = 'completed'
     canceled = 'canceled'

--- a/exa_py/websets/types.py
+++ b/exa_py/websets/types.py
@@ -2038,6 +2038,7 @@ class WebsetStatus(Enum):
     """
 
     idle = 'idle'
+    pending = 'pending'
     running = 'running'
     paused = 'paused'
 


### PR DESCRIPTION
## Summary
Adds the missing `pending` status to the `WebsetStatus` and `WebsetSearchStatus` enum. We are receiving the `pending` status in the webset create API, but the SDK was missing this value, causing the `ValidationError` when validating the response.

## Error:
```py
2 validation errors for Webset
status
  Input should be 'idle', 'running' or 'paused' [type=enum, input_value='pending', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/enum
searches.0.status
  Input should be 'created', 'running', 'completed' or 'canceled' [type=enum, input_value='pending', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/enum
```

**Trace:** puts it right at the `model_validate` call with `response.status` containing `pending`
```py
        Returns:
            Webset: The created webset.
        """
        response = await self.request("/v0/websets", data=params, options=options)
        return Webset.model_validate(response) <<<<<
```

----

_[API reference](https://exa.ai/docs/websets/api/websets/create-a-webset#response-status) does say pending status is possible_
