### PR TITLE
[exa-py]: support search output_schema across search types

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,27 +60,28 @@ results = exa.search(
 ```python
 results = exa.search(
     "What are the latest battery breakthroughs?",
-    type="deep",
-    system_prompt="Prefer official sources and avoid duplicate results",
+    type="auto",
     output_schema={
         "type": "object",
         "properties": {
-            "summary": {"type": "string"},
+            "answer_text": {"type": "string"},
             "key_companies": {"type": "array", "items": {"type": "string"}},
         },
-        "required": ["summary", "key_companies"],
+        "required": ["answer_text", "key_companies"],
     },
 )
 print(results.output.content if results.output else None)
 ```
 
-Deep `output_schema` modes:
+`output_schema` modes:
 - `{"type": "text", "description": "..."}`: return plain text in `output.content`
 - `{"type": "object", ...}`: return structured JSON in `output.content`
 
+All `/search` types support `output_schema`.
+
 Deep search also supports `system_prompt` to guide both the search process and the final returned result, for example by preferring certain sources, emphasizing novel findings, avoiding duplicates, or constraining output style.
 
-For `type: "object"`, deep search currently enforces:
+For `type: "object"`, `/search` currently enforces:
 - max nesting depth: `2`
 - max total properties: `10`
 

--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -269,29 +269,34 @@ SearchType = Literal[
 """Search type that determines the search algorithm. 'auto' (default) automatically selects the best approach, 'fast' prioritizes speed, 'deep' is light deep search, 'deep-reasoning' is base deep search, 'neural' uses embedding-based semantic search, and 'instant' uses low-latency neural search."""
 
 
-class DeepTextOutputSchema(TypedDict, total=False):
-    """Deep search output schema for plain-text output."""
+class SearchTextOutputSchema(TypedDict, total=False):
+    """Search output schema for plain-text synthesized output."""
 
     type: Literal["text"]
     description: str
 
 
-class DeepObjectOutputSchema(TypedDict, total=False):
-    """Deep search output schema for structured JSON object output."""
+class SearchObjectOutputSchema(TypedDict, total=False):
+    """Search output schema for structured JSON object output."""
 
     type: Literal["object"]
     properties: Dict[str, Any]
     required: List[str]
 
 
-DeepOutputSchema = Union[DeepTextOutputSchema, DeepObjectOutputSchema]
-"""Deep search output schema.
+SearchOutputSchema = Union[SearchTextOutputSchema, SearchObjectOutputSchema]
+"""Search output schema.
 
 - ``{"type": "text", "description": ...}`` returns plain text in ``output.content``.
 - ``{"type": "object", ...}`` returns structured JSON in ``output.content``.
 
 For object schemas, the API enforces max nesting depth 2 and max 10 total properties.
 """
+
+# Backwards-compatible aliases for older deep-search naming.
+DeepTextOutputSchema = SearchTextOutputSchema
+DeepObjectOutputSchema = SearchObjectOutputSchema
+DeepOutputSchema = SearchOutputSchema
 
 SEARCH_OPTIONS_TYPES = {
     "query": [str],  # The query string.
@@ -326,7 +331,7 @@ SEARCH_OPTIONS_TYPES = {
         list
     ],  # Alternative query formulations for deep search variants (max 5). Only used when type is deep/deep-reasoning.
     "system_prompt": [str],  # Deep-search-only instructions for search planning and final synthesis.
-    "output_schema": [dict],  # Deep output schema: {"type":"text"} or {"type":"object", ...}
+    "output_schema": [dict],  # Search output schema: {"type":"text"} or {"type":"object", ...}
 }
 
 FIND_SIMILAR_OPTIONS_TYPES = {
@@ -1224,7 +1229,7 @@ class SearchResponse(Generic[T]):
         resolved_search_type (str, optional): 'neural' or 'keyword' if auto.
         auto_date (str, optional): A date for filtering if autoprompt found one.
         context (str, optional): Deprecated. Combined context string when requested via contents.context. Use highlights or text instead.
-        output (DeepSearchOutput, optional): Deep search synthesized output object containing content and field-level grounding.
+        output (SearchOutput, optional): Synthesized search output object containing content and field-level grounding.
         statuses (List[ContentStatus], optional): Status list from get_contents.
         cost_dollars (CostDollars, optional): Cost breakdown.
         search_time (float, optional): Time taken for the search in milliseconds.
@@ -1234,7 +1239,7 @@ class SearchResponse(Generic[T]):
     resolved_search_type: Optional[str]
     auto_date: Optional[str]
     context: Optional[str] = None
-    output: Optional["DeepSearchOutput"] = None
+    output: Optional["SearchOutput"] = None
     statuses: Optional[List[ContentStatus]] = None
     cost_dollars: Optional[CostDollars] = None
     search_time: Optional[float] = None
@@ -1261,42 +1266,42 @@ class SearchResponse(Generic[T]):
 
 
 @dataclass
-class DeepSearchOutputGroundingCitation:
+class SearchOutputGroundingCitation:
     """Citation metadata for one grounded output field."""
 
     url: str
     title: str
 
 
-DeepSearchOutputGroundingConfidence = Literal["low", "medium", "high"]
+SearchOutputGroundingConfidence = Literal["low", "medium", "high"]
 """Confidence levels for a grounded output field."""
 
 
 @dataclass
-class DeepSearchOutputGrounding:
-    """Grounding metadata for one field in deep-search synthesized output."""
+class SearchOutputGrounding:
+    """Grounding metadata for one field in synthesized search output."""
 
     field: str
-    citations: List[DeepSearchOutputGroundingCitation]
-    confidence: DeepSearchOutputGroundingConfidence
+    citations: List[SearchOutputGroundingCitation]
+    confidence: SearchOutputGroundingConfidence
 
 
 @dataclass
-class DeepSearchOutput:
-    """Deep-search synthesized output payload."""
+class SearchOutput:
+    """Synthesized output payload returned from `/search` when `output_schema` is provided."""
 
     content: Union[str, dict[str, Any]]
-    grounding: List[DeepSearchOutputGrounding]
+    grounding: List[SearchOutputGrounding]
 
 
-def parse_deep_search_output(raw: Any) -> Optional[DeepSearchOutput]:
-    """Parse deep-search output into a typed object.
+def parse_search_output(raw: Any) -> Optional[SearchOutput]:
+    """Parse synthesized search output into a typed object.
 
     Args:
         raw: Raw `output` field from API response.
 
     Returns:
-        Parsed DeepSearchOutput when the payload is an object, otherwise None.
+        Parsed SearchOutput when the payload is an object, otherwise None.
     """
 
     if not isinstance(raw, dict):
@@ -1310,7 +1315,7 @@ def parse_deep_search_output(raw: Any) -> Optional[DeepSearchOutput]:
     else:
         content = ""
 
-    grounding: List[DeepSearchOutputGrounding] = []
+    grounding: List[SearchOutputGrounding] = []
     raw_grounding = raw.get("grounding")
     if isinstance(raw_grounding, list):
         for grounding_row in raw_grounding:
@@ -1321,7 +1326,7 @@ def parse_deep_search_output(raw: Any) -> Optional[DeepSearchOutput]:
             if not isinstance(field, str):
                 continue
 
-            citations: List[DeepSearchOutputGroundingCitation] = []
+            citations: List[SearchOutputGroundingCitation] = []
             raw_citations = grounding_row.get("citations")
             if isinstance(raw_citations, list):
                 for citation in raw_citations:
@@ -1332,7 +1337,7 @@ def parse_deep_search_output(raw: Any) -> Optional[DeepSearchOutput]:
                     if not isinstance(url, str):
                         continue
                     citations.append(
-                        DeepSearchOutputGroundingCitation(
+                        SearchOutputGroundingCitation(
                             url=url,
                             title=title if isinstance(title, str) else "",
                         )
@@ -1343,14 +1348,22 @@ def parse_deep_search_output(raw: Any) -> Optional[DeepSearchOutput]:
                 confidence = "medium"
 
             grounding.append(
-                DeepSearchOutputGrounding(
+                SearchOutputGrounding(
                     field=field,
                     citations=citations,
                     confidence=confidence,
                 )
             )
 
-    return DeepSearchOutput(content=content, grounding=grounding)
+    return SearchOutput(content=content, grounding=grounding)
+
+
+# Backwards-compatible aliases for older deep-search naming.
+DeepSearchOutputGroundingCitation = SearchOutputGroundingCitation
+DeepSearchOutputGroundingConfidence = SearchOutputGroundingConfidence
+DeepSearchOutputGrounding = SearchOutputGrounding
+DeepSearchOutput = SearchOutput
+parse_deep_search_output = parse_search_output
 
 
 def nest_fields(original_dict: Dict, fields_to_nest: List[str], new_key: str):
@@ -1513,7 +1526,7 @@ class Exa:
         user_location: Optional[str] = None,
         additional_queries: Optional[List[str]] = None,
         system_prompt: Optional[str] = None,
-        output_schema: Optional[DeepOutputSchema] = None,
+        output_schema: Optional[SearchOutputSchema] = None,
     ) -> SearchResponse[Result]:
         """Perform a search.
 
@@ -1547,11 +1560,10 @@ class Exa:
                 search process and the final returned result. Use this to prefer certain sources,
                 emphasize novelty, avoid duplicates, or constrain the response style.
                 Only applicable when type is 'deep' or 'deep-reasoning'.
-            output_schema (DeepOutputSchema, optional): Deep output schema for deep search.
+            output_schema (SearchOutputSchema, optional): Output schema for synthesized `/search` output across all search types.
                 Use ``{"type": "text", "description": ...}`` for plain text output or
                 ``{"type": "object", "properties": ..., "required": ...}`` for structured JSON.
                 For object schemas, max nesting depth is 2 and max total properties is 10.
-                Only applicable when type is 'deep' or 'deep-reasoning'.
 
         Returns:
             SearchResponse: The response containing search results, etc.
@@ -1569,6 +1581,17 @@ class Exa:
               type="deep",
               additional_queries=["AI blogpost", "machine learning blogs"],
               num_results=5
+            )
+
+            # Structured output is supported across all search types
+            structured_result = exa.search(
+              "recent battery breakthroughs",
+              type="auto",
+              output_schema={
+                  "type": "object",
+                  "properties": {"answer_text": {"type": "string"}},
+                  "required": ["answer_text"],
+              }
             )
         """
         options = {k: v for k, v in locals().items() if k != "self" and v is not None}
@@ -1615,7 +1638,7 @@ class Exa:
             data["resolvedSearchType"] if "resolvedSearchType" in data else None,
             data["autoDate"] if "autoDate" in data else None,
             context=data.get("context"),
-            output=parse_deep_search_output(data.get("output")),
+            output=parse_search_output(data.get("output")),
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
         )
@@ -1671,7 +1694,7 @@ class Exa:
             ],
             "contents",
         )
-        options = to_camel_case(options, skip_keys=["schema"])
+        options = to_camel_case(options, skip_keys=["schema", "output_schema"])
         data = self.request("/search", options)
         cost_dollars = parse_cost_dollars(data.get("costDollars"))
         results = []
@@ -1701,7 +1724,7 @@ class Exa:
             data.get("resolvedSearchType"),
             data.get("autoDate"),
             context=data.get("context"),
-            output=parse_deep_search_output(data.get("output")),
+            output=parse_search_output(data.get("output")),
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
         )
@@ -2551,7 +2574,7 @@ class AsyncExa(Exa):
         user_location: Optional[str] = None,
         additional_queries: Optional[List[str]] = None,
         system_prompt: Optional[str] = None,
-        output_schema: Optional[DeepOutputSchema] = None,
+        output_schema: Optional[SearchOutputSchema] = None,
     ) -> SearchResponse[Result]:
         """Perform a search with a prompt-engineered query to retrieve relevant results.
 
@@ -2585,11 +2608,10 @@ class AsyncExa(Exa):
                 search process and the final returned result. Use this to prefer certain sources,
                 emphasize novelty, avoid duplicates, or constrain the response style.
                 Only applicable when type is 'deep' or 'deep-reasoning'.
-            output_schema (DeepOutputSchema, optional): Deep output schema for deep search.
+            output_schema (SearchOutputSchema, optional): Output schema for synthesized `/search` output across all search types.
                 Use ``{"type": "text", "description": ...}`` for plain text output or
                 ``{"type": "object", "properties": ..., "required": ...}`` for structured JSON.
                 For object schemas, max nesting depth is 2 and max total properties is 10.
-                Only applicable when type is 'deep' or 'deep-reasoning'.
 
         Returns:
             SearchResponse: The response containing search results, etc.
@@ -2605,6 +2627,17 @@ class AsyncExa(Exa):
             ...     "climate change research",
             ...     include_domains=["nature.com", "science.org"],
             ...     start_published_date="2024-01-01"
+            ... )
+
+            Structured async output:
+            >>> results = await async_exa.search(
+            ...     "recent battery breakthroughs",
+            ...     type="auto",
+            ...     output_schema={
+            ...         "type": "object",
+            ...         "properties": {"answer_text": {"type": "string"}},
+            ...         "required": ["answer_text"],
+            ...     },
             ... )
         """
         options = {k: v for k, v in locals().items() if k != "self" and v is not None}
@@ -2651,7 +2684,7 @@ class AsyncExa(Exa):
             data.get("resolvedSearchType"),
             data.get("autoDate"),
             context=data.get("context"),
-            output=parse_deep_search_output(data.get("output")),
+            output=parse_search_output(data.get("output")),
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
         )
@@ -2707,7 +2740,7 @@ class AsyncExa(Exa):
             ],
             "contents",
         )
-        options = to_camel_case(options, skip_keys=["schema"])
+        options = to_camel_case(options, skip_keys=["schema", "output_schema"])
         data = await self.async_request("/search", options)
         cost_dollars = parse_cost_dollars(data.get("costDollars"))
         results = []
@@ -2737,6 +2770,7 @@ class AsyncExa(Exa):
             data.get("resolvedSearchType"),
             data.get("autoDate"),
             context=data.get("context"),
+            output=parse_search_output(data.get("output")),
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.8.0"
+version = "2.9.0"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.8.0"
+version = "2.9.0"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/unit/test_search_api.py
+++ b/tests/unit/test_search_api.py
@@ -166,6 +166,113 @@ def test_search_accepts_deep_reasoning_params_offline():
         assert "answerText" not in options["outputSchema"]["properties"]
 
 
+def test_search_accepts_output_schema_for_auto_search_offline():
+    """Test non-deep search accepts output_schema params."""
+    exa = Exa(API_KEY)
+    mock_response = {
+        "results": [
+            {"url": "http://example.com", "id": "1", "title": "Search Result"}
+        ],
+        "output": {
+            "content": {"answer_text": "Search synthesis"},
+            "grounding": [
+                {
+                    "field": "answer_text",
+                    "citations": [
+                        {"url": "http://example.com", "title": "Search Result"}
+                    ],
+                    "confidence": "high",
+                }
+            ],
+        },
+        "costDollars": {"total": 0.002},
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "answer_text": {"type": "string"},
+        },
+        "required": ["answer_text"],
+    }
+
+    with patch.object(exa, "request", return_value=mock_response) as mock_request:
+        resp = exa.search(
+            "machine learning",
+            type="auto",
+            output_schema=output_schema,
+            num_results=5,
+        )
+        assert isinstance(resp, exa_api.SearchResponse)
+        assert resp.output is not None
+        assert resp.output.content == {"answer_text": "Search synthesis"}
+        assert len(resp.output.grounding) == 1
+        assert resp.output.grounding[0].field == "answer_text"
+        assert resp.output.grounding[0].confidence == "high"
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "/search"
+        options = call_args[0][1]
+        assert options["type"] == "auto"
+        assert "outputSchema" in options
+        assert options["outputSchema"]["properties"]["answer_text"]["type"] == "string"
+        assert "answerText" not in options["outputSchema"]["properties"]
+
+
+def test_search_and_contents_accepts_output_schema_offline():
+    """Test deprecated search_and_contents preserves output_schema field names."""
+    exa = Exa(API_KEY)
+    mock_response = {
+        "results": [
+            {
+                "url": "http://example.com",
+                "id": "1",
+                "title": "Search Result",
+                "text": "Sample text",
+            }
+        ],
+        "output": {
+            "content": {"answer_text": "Search synthesis"},
+            "grounding": [
+                {
+                    "field": "answer_text",
+                    "citations": [
+                        {"url": "http://example.com", "title": "Search Result"}
+                    ],
+                    "confidence": "high",
+                }
+            ],
+        },
+        "costDollars": {"total": 0.002},
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "answer_text": {"type": "string"},
+        },
+        "required": ["answer_text"],
+    }
+
+    with patch.object(exa, "request", return_value=mock_response) as mock_request:
+        resp = exa.search_and_contents(
+            "machine learning",
+            type="auto",
+            output_schema=output_schema,
+            num_results=5,
+        )
+        assert isinstance(resp, exa_api.SearchResponse)
+        assert resp.output is not None
+        assert resp.output.content == {"answer_text": "Search synthesis"}
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "/search"
+        options = call_args[0][1]
+        assert "outputSchema" in options
+        assert options["outputSchema"]["properties"]["answer_text"]["type"] == "string"
+        assert "answerText" not in options["outputSchema"]["properties"]
+
+
 def test_search_accepts_deep_system_prompt_offline():
     """Test deep search accepts system_prompt and forwards it as camelCase."""
     exa = Exa(API_KEY)
@@ -224,6 +331,55 @@ async def test_async_search_accepts_deepv3_params_offline():
         assert call_args[0][0] == "/search"
         options = call_args[0][1]
         assert options["type"] == "deep-reasoning"
+        assert options["outputSchema"]["properties"]["answer_text"]["type"] == "string"
+        assert "answerText" not in options["outputSchema"]["properties"]
+
+
+@pytest.mark.asyncio
+async def test_async_search_accepts_output_schema_for_auto_search_offline():
+    """Test async non-deep search accepts output_schema params."""
+    ax = AsyncExa(API_KEY)
+    mock_response = {
+        "results": [{"url": "http://example.com", "id": "1", "title": "Async Result"}],
+        "output": {
+            "content": {"answer_text": "Async synthesis"},
+            "grounding": [
+                {
+                    "field": "answer_text",
+                    "citations": [
+                        {"url": "http://example.com", "title": "Async Result"}
+                    ],
+                    "confidence": "high",
+                }
+            ],
+        },
+        "costDollars": {"total": 0.001},
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "answer_text": {"type": "string"},
+        },
+        "required": ["answer_text"],
+    }
+
+    with patch.object(
+        ax, "async_request", new=AsyncMock(return_value=mock_response)
+    ) as mock_async_request:
+        resp = await ax.search(
+            "async query",
+            type="auto",
+            output_schema=output_schema,
+        )
+        assert isinstance(resp, exa_api.SearchResponse)
+        assert resp.output is not None
+        assert resp.output.content == {"answer_text": "Async synthesis"}
+
+        call_args = mock_async_request.call_args
+        assert call_args[0][0] == "/search"
+        options = call_args[0][1]
+        assert options["type"] == "auto"
         assert options["outputSchema"]["properties"]["answer_text"]["type"] == "string"
         assert "answerText" not in options["outputSchema"]["properties"]
 


### PR DESCRIPTION
## Summary
- expose `output_schema` for all `/search` types in the Python SDK while keeping the existing deep-search type names as aliases
- update the synthesized output types/docs to use generic `Search*` names and keep backwards-compatible `Deep*` aliases
- refresh README examples/docs, cover non-deep structured output in unit tests, and bump `exa-py` from `2.8.0` to `2.9.0`

## Validation
- `.venv/bin/pytest -q tests/unit/test_search_api.py`
- `python3 -m py_compile exa_py/api.py tests/unit/test_search_api.py`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-py/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
