### PR TITLE
fixed TypeError: ContentStatus.__init__()

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -1214,6 +1214,7 @@ class ContentStatus:
     id: str
     status: str
     source: str
+    error: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
This PR fixes the TypeError in ContentStatus initialization 
where an unexpected keyword argument 'error' was passed.

Fixes #104