### PR TITLE
Replace cron triggers with interval-based scheduling for search monitors

### DIFF
--- a/docs/python-sdk-specification.mdx
+++ b/docs/python-sdk-specification.mdx
@@ -626,9 +626,8 @@ monitor = exa.monitors.create(
             "numResults": 5,
         },
         "trigger": {
-            "type": "cron",
-            "expression": "0 * * * *",
-            "timezone": "UTC",
+            "type": "interval",
+            "period": "1h",
         },
         "webhook": {
             "url": "https://example.com/webhooks/search-monitors",
@@ -661,9 +660,8 @@ print(monitor.id)
     }
   },
   "trigger": {
-    "type": "cron",
-    "expression": "0 * * * *",
-    "timezone": "UTC"
+    "type": "interval",
+    "period": "1h"
   },
   "webhook": {
     "url": "https://example.com/webhooks/search-monitors",
@@ -732,9 +730,8 @@ print(monitor.status)
     }
   },
   "trigger": {
-    "type": "cron",
-    "expression": "0 * * * *",
-    "timezone": "UTC"
+    "type": "interval",
+    "period": "1h"
   },
   "webhook": {
     "url": "https://example.com/webhooks/search-monitors",
@@ -1792,9 +1789,8 @@ accept either True (for defaults) or an options object.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| type | Literal['cron'] | - |
-| expression | str | - |
-| timezone | Optional[str] | - |
+| type | Literal['interval'] | - |
+| period | str | - |
 
 #### `SearchMonitorWebhook`
 
@@ -1935,7 +1931,7 @@ Input type for JSON schema parameters. Can be either a Pydantic model class (aut
 
 Data category to focus on when searching. Each category returns results specialized for that content type.
 
-**Type:** Literal['company', 'research paper', 'news', 'pdf', 'tweet', 'personal site', 'financial report', 'people']
+**Type:** Literal['company', 'research paper', 'news', 'pdf', 'personal site', 'financial report', 'people']
 
 #### `SearchType`
 

--- a/exa_py/monitors/client.py
+++ b/exa_py/monitors/client.py
@@ -143,9 +143,8 @@ class SearchMonitorsClient(SearchMonitorsBaseClient):
                         "numResults": 5,
                     },
                     "trigger": {
-                        "type": "cron",
-                        "expression": "0 * * * *",
-                        "timezone": "UTC",
+                        "type": "interval",
+                        "period": "1h",
                     },
                     "webhook": {
                         "url": "https://example.com/webhooks/search-monitors",

--- a/exa_py/monitors/types.py
+++ b/exa_py/monitors/types.py
@@ -135,9 +135,8 @@ class SearchMonitorSearch(BaseModel):
 
 
 class SearchMonitorTrigger(BaseModel):
-    type: Literal["cron"]
-    expression: str
-    timezone: Optional[str] = None
+    type: Literal["interval"]
+    period: str
 
     model_config = {"populate_by_name": True}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.10.1"
+version = "2.10.2"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.10.1"
+version = "2.10.2"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/gen_config.json
+++ b/scripts/gen_config.json
@@ -148,9 +148,8 @@
         }
       },
       "trigger": {
-        "type": "cron",
-        "expression": "0 * * * *",
-        "timezone": "UTC"
+        "type": "interval",
+        "period": "1h"
       },
       "webhook": {
         "url": "https://example.com/webhooks/search-monitors",
@@ -173,9 +172,8 @@
         }
       },
       "trigger": {
-        "type": "cron",
-        "expression": "0 * * * *",
-        "timezone": "UTC"
+        "type": "interval",
+        "period": "1h"
       },
       "webhook": {
         "url": "https://example.com/webhooks/search-monitors",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.10.1",
+    version="2.10.2",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/unit/test_search_monitors.py
+++ b/tests/unit/test_search_monitors.py
@@ -26,7 +26,7 @@ def _make_monitor(id: str) -> dict:
         "name": f"Monitor {id}",
         "status": "active",
         "search": {"query": "test"},
-        "trigger": {"type": "cron", "expression": "0 9 * * *", "timezone": "Etc/UTC"},
+        "trigger": {"type": "interval", "period": "1d"},
         "outputSchema": None,
         "metadata": None,
         "webhook": {"url": "https://example.com/hook"},

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.10.1"
+version = "2.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary

- Update `SearchMonitorTrigger` type from `{ type: "cron", expression, timezone }` to `{ type: "interval", period }`
- Update docstring example in create method
- Update test fixtures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-py/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
