### PR TITLE
[codex] Support search schema on all search types

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ results = exa.search(
 ```python
 results = exa.search(
     "What are the latest battery breakthroughs?",
-    type="deep",
+    type="auto",
     system_prompt="Prefer official sources and avoid duplicate results",
     output_schema={
         "type": "object",
@@ -68,19 +68,20 @@ results = exa.search(
 print(results.output.content if results.output else None)
 ```
 
-Deep `output_schema` modes:
+Search `output_schema` modes:
 - `{"type": "text", "description": "..."}`: return plain text in `output.content`
 - `{"type": "object", ...}`: return structured JSON in `output.content`
 
-Deep search also supports `system_prompt` to guide both the search process and the final returned result, for example by preferring certain sources, emphasizing novel findings, avoiding duplicates, or constraining output style.
+`system_prompt` and `output_schema` are supported on every search type.
 
-For `type: "object"`, deep search currently enforces:
+For `type: "object"`, search currently enforces:
 - max nesting depth: `2`
 - max total properties: `10`
 
-Deep search variants:
-- `deep`: light mode
-- `deep-reasoning`: base reasoning mode
+Deep search variants that also support `additional_queries`:
+- `deep-lite`
+- `deep`
+- `deep-reasoning`
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,21 @@ results = exa.search(
 print(results.output.content if results.output else None)
 ```
 
+```python
+for chunk in exa.stream_search(
+    "What are the latest battery breakthroughs?",
+    type="auto",
+):
+    if chunk.content:
+        print(chunk.content, end="", flush=True)
+```
+
 Search `output_schema` modes:
 - `{"type": "text", "description": "..."}`: return plain text in `output.content`
 - `{"type": "object", ...}`: return structured JSON in `output.content`
 
 `system_prompt` and `output_schema` are supported on every search type.
+Search streaming is available via `stream_search(...)`, which yields OpenAI-style chat completion chunks.
 
 For `type: "object"`, search currently enforces:
 - max nesting depth: `2`

--- a/docs/python-sdk-specification.mdx
+++ b/docs/python-sdk-specification.mdx
@@ -79,14 +79,14 @@ deep_result = exa.search(
 | end_published_date | Optional[str] | Only links published before this date. | None |
 | include_text | Optional[List[str]] | Strings that must appear in the page text. | None |
 | exclude_text | Optional[List[str]] | Strings that must not appear in the page text. | None |
-| type | Optional[Union[[SearchType](#searchtype), str]] | Search type - 'auto' (default), 'fast', 'deep', 'deep-reasoning', 'neural', or 'instant'. | None |
+| type | Optional[Union[[SearchType](#searchtype), str]] | Search type - 'auto' (default), 'fast', 'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'. | None |
 | category | Optional[[Category](#category)] | Data category to focus on (e.g. 'company', 'news', 'research paper'). | None |
 | flags | Optional[List[str]] | Experimental flags for Exa usage. | None |
 | moderation | Optional[bool] | If True, the search results will be moderated for safety. | None |
 | user_location | Optional[str] | Two-letter ISO country code of the user (e.g. US). | None |
-| additional_queries | Optional[List[str]] | Alternative query formulations for deep search to skip automatic LLM-based query expansion. Max 5 queries. Only applicable when type is 'deep' or 'deep-reasoning'. Example: ["machine learning", "ML algorithms", "neural networks"] | None |
-| system_prompt | Optional[str] | Deep-search-only instructions that guide both the search process and the final returned result. Use this to prefer certain sources, emphasize novelty, avoid duplicates, or constrain the response style. Only applicable when type is 'deep' or 'deep-reasoning'. | None |
-| output_schema | Optional[[DeepOutputSchema](#deepoutputschema)] | Deep output schema for deep search. Use ``{"type": "text", "description": ...}`` for plain text output or ``{"type": "object", "properties": ..., "required": ...}`` for structured JSON. For object schemas, max nesting depth is 2 and max total properties is 10. Only applicable when type is 'deep' or 'deep-reasoning'. | None |
+| additional_queries | Optional[List[str]] | Alternative query formulations for deep search to skip automatic LLM-based query expansion. Max 5 queries. Only applicable when type is 'deep-lite', 'deep', or 'deep-reasoning'. Example: ["machine learning", "ML algorithms", "neural networks"] | None |
+| system_prompt | Optional[str] | Instructions that guide both the search process and the final returned result. Use this to prefer certain sources, emphasize novelty, avoid duplicates, or constrain the response style. Supported for all search types. | None |
+| output_schema | Optional[[DeepOutputSchema](#deepoutputschema)] | Search output schema for structured synthesis. When provided, the API returns synthesized output in ``output``. Use ``{"type": "text", "description": ...}`` for plain text output or ``{"type": "object", "properties": ..., "required": ...}`` for structured JSON. For object schemas, max nesting depth is 2 and max total properties is 10. Supported for all search types. | None |
 
 ### Return Example
 
@@ -1419,7 +1419,7 @@ A class representing the response for a search operation.
 | resolved_search_type | Optional[str] | 'neural' or 'keyword' if auto. |
 | auto_date | Optional[str] | A date for filtering if autoprompt found one. |
 | context | Optional[str] | Deprecated. Combined context string when requested via contents.context. Use highlights or text instead. |
-| output | Optional['[DeepSearchOutput](#deepsearchoutput)'] | Deep search synthesized output object containing content and field-level grounding. |
+| output | Optional['[DeepSearchOutput](#deepsearchoutput)'] | Search synthesized output object returned when output_schema is provided, containing content and field-level grounding. |
 | statuses | Optional[List[[ContentStatus](#contentstatus)]] | Status list from get_contents. |
 | cost_dollars | Optional[[CostDollars](#costdollars)] | Cost breakdown. |
 | search_time | Optional[float] | Time taken for the search in milliseconds. |
@@ -1435,7 +1435,7 @@ Citation metadata for one grounded output field.
 
 #### `DeepSearchOutputGrounding`
 
-Grounding metadata for one field in deep-search synthesized output.
+Grounding metadata for one field in search synthesized output.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
@@ -1445,7 +1445,7 @@ Grounding metadata for one field in deep-search synthesized output.
 
 #### `DeepSearchOutput`
 
-Deep-search synthesized output payload.
+Search synthesized output payload.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
@@ -1935,13 +1935,19 @@ Data category to focus on when searching. Each category returns results speciali
 
 #### `SearchType`
 
-Search type that determines the search algorithm. 'auto' (default) automatically selects the best approach, 'fast' prioritizes speed, 'deep' is light deep search, 'deep-reasoning' is base deep search, 'neural' uses embedding-based semantic search, and 'instant' uses low-latency neural search.
+Search type that determines the search algorithm.
 
-**Type:** Literal['auto', 'fast', 'deep', 'deep-reasoning', 'neural', 'instant']
+'auto' (default) automatically selects the best approach, 'fast' prioritizes
+speed, 'deep-lite', 'deep', and 'deep-reasoning' are deep-search variants,
+'neural' uses embedding-based semantic search, and 'instant' uses low-latency
+neural search.
+
+
+**Type:** Literal['auto', 'fast', 'deep-lite', 'deep', 'deep-reasoning', 'neural', 'instant']
 
 #### `DeepOutputSchema`
 
-Deep search output schema.
+Search output schema.
 
 - ``{"type": "text", "description": ...}`` returns plain text in ``output.content``.
 - ``{"type": "object", ...}`` returns structured JSON in ``output.content``.

--- a/docs/python-sdk-specification.mdx
+++ b/docs/python-sdk-specification.mdx
@@ -69,6 +69,7 @@ deep_result = exa.search(
 | Parameter | Type | Description | Default |
 | --------- | ---- | ----------- | ------- |
 | query | str | The query string. | Required |
+| stream | Optional[bool] | If True, stream the synthesized search response. Use ``stream_search(...)`` instead of ``search(..., stream=True)``. | `False` |
 | contents | Optional[Union[[ContentsOptions](#contentsoptions), Literal[False]]] | Options for retrieving page contents. Defaults to `{"text": {"maxCharacters": 10000}`}. Use False to disable contents. See [ContentsOptions](#contentsoptions) for available options (text, highlights, summary, etc.). Note: The ``context`` option is deprecated; use ``highlights`` or ``text`` instead. | None |
 | num_results | Optional[int] | Number of search results to return. Default 10. | None |
 | include_domains | Optional[List[str]] | Domains to include in the search. | None |
@@ -369,8 +370,8 @@ for chunk in stream:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| content | Optional[str] | The partial text content of the answer |
-| citations | Optional[List[[AnswerResult](#answerresult)]] | List of citations if provided in this chunk |
+| content | Optional[str] | The partial text content of the streamed response. |
+| citations | Optional[List[[AnswerResult](#answerresult)]] | List of citations if provided in this chunk. |
 
 ## `research.create` Method
 
@@ -1378,8 +1379,8 @@ A class representing a single chunk of streaming data.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| content | Optional[str] | The partial text content of the answer |
-| citations | Optional[List[[AnswerResult](#answerresult)]] | List of citations if provided in this chunk |
+| content | Optional[str] | The partial text content of the streamed response. |
+| citations | Optional[List[[AnswerResult](#answerresult)]] | List of citations if provided in this chunk. |
 
 #### `AnswerResponse`
 
@@ -1398,6 +1399,14 @@ A class representing a streaming answer response.
 #### `AsyncStreamAnswerResponse`
 
 A class representing a streaming answer response.
+
+#### `StreamSearchResponse`
+
+A class representing a streaming search response.
+
+#### `AsyncStreamSearchResponse`
+
+A class representing a streaming search response.
 
 #### `ContentStatus`
 

--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -335,6 +335,7 @@ SEARCH_OPTIONS_TYPES = {
     ],  # Alternative query formulations for deep search variants (max 5). Only used when type is deep-lite/deep/deep-reasoning.
     "system_prompt": [str],  # Instructions for search planning and final synthesis across all search types.
     "output_schema": [dict],  # Search output schema: {"type":"text"} or {"type":"object", ...}
+    "stream": [bool],  # If true, stream back OpenAI-style chat completion chunks.
 }
 
 FIND_SIMILAR_OPTIONS_TYPES = {
@@ -1042,8 +1043,8 @@ class StreamChunk:
     """A class representing a single chunk of streaming data.
 
     Attributes:
-        content (Optional[str]): The partial text content of the answer
-        citations (Optional[List[AnswerResult]]): List of citations if provided in this chunk
+        content (Optional[str]): The partial text content of the streamed response.
+        citations (Optional[List[AnswerResult]]): List of citations if provided in this chunk.
     """
 
     content: Optional[str] = None
@@ -1209,6 +1210,14 @@ class AsyncStreamAnswerResponse:
     def close(self) -> None:
         """Close the underlying raw response to release the network socket."""
         self._raw_response.close()
+
+
+class StreamSearchResponse(StreamAnswerResponse):
+    """A class representing a streaming search response."""
+
+
+class AsyncStreamSearchResponse(AsyncStreamAnswerResponse):
+    """A class representing a streaming search response."""
 
 
 T = TypeVar("T")
@@ -1508,6 +1517,7 @@ class Exa:
         self,
         query: str,
         *,
+        stream: Optional[bool] = False,
         contents: Optional[Union[ContentsOptions, Literal[False]]] = None,
         num_results: Optional[int] = None,
         include_domains: Optional[List[str]] = None,
@@ -1533,6 +1543,8 @@ class Exa:
 
         Args:
             query (str): The query string.
+            stream (bool, optional): If True, stream the synthesized search response.
+                Use ``stream_search(...)`` instead of ``search(..., stream=True)``.
             contents (ContentsOptions | False, optional): Options for retrieving page contents.
                 Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
                 See ContentsOptions for available options (text, highlights, summary, etc.).
@@ -1569,6 +1581,9 @@ class Exa:
         Returns:
             SearchResponse: The response containing search results, etc.
 
+        Raises:
+            ValueError: If stream=True is provided. Use stream_search() instead.
+
         Examples:
             # Basic search
             result = exa.search(
@@ -1585,7 +1600,14 @@ class Exa:
               num_results=5
             )
         """
+        if stream:
+            raise ValueError(
+                "stream=True is not supported in `search()`. "
+                "Please use `stream_search(...)` for streaming."
+            )
+
         options = {k: v for k, v in locals().items() if k != "self" and v is not None}
+        options.pop("stream", None)
 
         # Handle contents parameter with default behavior
         if contents is False:
@@ -1633,6 +1655,83 @@ class Exa:
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
         )
+
+    def stream_search(
+        self,
+        query: str,
+        *,
+        contents: Optional[Union[ContentsOptions, Literal[False]]] = None,
+        num_results: Optional[int] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        start_crawl_date: Optional[str] = None,
+        end_crawl_date: Optional[str] = None,
+        start_published_date: Optional[str] = None,
+        end_published_date: Optional[str] = None,
+        include_text: Optional[List[str]] = None,
+        exclude_text: Optional[List[str]] = None,
+        type: Optional[Union[SearchType, str]] = None,
+        category: Optional[Category] = None,
+        flags: Optional[List[str]] = None,
+        moderation: Optional[bool] = None,
+        user_location: Optional[str] = None,
+        additional_queries: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+        output_schema: Optional[DeepOutputSchema] = None,
+    ) -> StreamSearchResponse:
+        """Generate a streaming search response.
+
+        Args:
+            query (str): The query string.
+            contents (ContentsOptions | False, optional): Options for retrieving page contents.
+                Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
+            num_results (int, optional): Number of search results to return. Default 10.
+            include_domains (List[str], optional): Domains to include in the search.
+            exclude_domains (List[str], optional): Domains to exclude from the search.
+            start_crawl_date (str, optional): Only links crawled after this date.
+            end_crawl_date (str, optional): Only links crawled before this date.
+            start_published_date (str, optional): Only links published after this date.
+            end_published_date (str, optional): Only links published before this date.
+            include_text (List[str], optional): Strings that must appear in the page text.
+            exclude_text (List[str], optional): Strings that must not appear in the page text.
+            type (SearchType, optional): Search type - 'auto' (default), 'fast',
+                'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'.
+            category (Category, optional): Data category to focus on.
+            flags (List[str], optional): Experimental flags for Exa usage.
+            moderation (bool, optional): If True, the search results will be moderated for safety.
+            user_location (str, optional): Two-letter ISO country code of the user (e.g. US).
+            additional_queries (List[str], optional): Alternative query formulations for deep search.
+            system_prompt (str, optional): Instructions that guide the search process and streamed synthesis.
+            output_schema (DeepOutputSchema, optional): Search output schema for structured synthesis.
+
+        Returns:
+            StreamSearchResponse: An iterator yielding OpenAI-style streaming chunks with
+                partial ``content`` and optional ``citations``.
+
+        Examples:
+            stream = exa.stream_search(
+                "What are the latest battery breakthroughs?",
+                type="auto"
+            )
+
+            for chunk in stream:
+                if chunk.content:
+                    print(chunk.content, end="", flush=True)
+        """
+        options = {k: v for k, v in locals().items() if k != "self" and v is not None}
+
+        if contents is False:
+            options.pop("contents", None)
+        elif contents is None and "contents" not in options:
+            options["contents"] = {"text": {"max_characters": DEFAULT_MAX_CHARACTERS}}
+        elif contents is not None:
+            options["contents"] = contents
+
+        validate_search_options(options, SEARCH_OPTIONS_TYPES)
+        options = to_camel_case(options, skip_keys=["output_schema"])
+        options["stream"] = True
+        raw_response = self.request("/search", options)
+        return StreamSearchResponse(raw_response)
 
     def search_and_contents(self, query: str, **kwargs):
         """
@@ -2560,6 +2659,7 @@ class AsyncExa(Exa):
         self,
         query: str,
         *,
+        stream: Optional[bool] = False,
         contents: Optional[Union[ContentsOptions, Literal[False]]] = None,
         num_results: Optional[int] = None,
         include_domains: Optional[List[str]] = None,
@@ -2585,6 +2685,8 @@ class AsyncExa(Exa):
 
         Args:
             query (str): The query string.
+            stream (bool, optional): If True, stream the synthesized search response.
+                Use ``stream_search(...)`` instead of ``search(..., stream=True)``.
             contents (ContentsOptions | False, optional): Options for retrieving page contents.
                 Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
                 See ContentsOptions for available options (text, highlights, summary, etc.).
@@ -2621,6 +2723,9 @@ class AsyncExa(Exa):
         Returns:
             SearchResponse: The response containing search results, etc.
 
+        Raises:
+            ValueError: If stream=True is provided. Use stream_search() instead.
+
         Examples:
             Basic async search:
             >>> async_exa = AsyncExa(api_key="your-api-key")
@@ -2634,7 +2739,14 @@ class AsyncExa(Exa):
             ...     start_published_date="2024-01-01"
             ... )
         """
+        if stream:
+            raise ValueError(
+                "stream=True is not supported in `search()`. "
+                "Please use `stream_search(...)` for streaming."
+            )
+
         options = {k: v for k, v in locals().items() if k != "self" and v is not None}
+        options.pop("stream", None)
 
         # Handle contents parameter with default behavior
         if contents is False:
@@ -2682,6 +2794,82 @@ class AsyncExa(Exa):
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
         )
+
+    async def stream_search(
+        self,
+        query: str,
+        *,
+        contents: Optional[Union[ContentsOptions, Literal[False]]] = None,
+        num_results: Optional[int] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        start_crawl_date: Optional[str] = None,
+        end_crawl_date: Optional[str] = None,
+        start_published_date: Optional[str] = None,
+        end_published_date: Optional[str] = None,
+        include_text: Optional[List[str]] = None,
+        exclude_text: Optional[List[str]] = None,
+        type: Optional[Union[SearchType, str]] = None,
+        category: Optional[Category] = None,
+        flags: Optional[List[str]] = None,
+        moderation: Optional[bool] = None,
+        user_location: Optional[str] = None,
+        additional_queries: Optional[List[str]] = None,
+        system_prompt: Optional[str] = None,
+        output_schema: Optional[DeepOutputSchema] = None,
+    ) -> AsyncStreamSearchResponse:
+        """Generate a streaming search response asynchronously.
+
+        Args:
+            query (str): The query string.
+            contents (ContentsOptions | False, optional): Options for retrieving page contents.
+                Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
+            num_results (int, optional): Number of search results to return. Default 10.
+            include_domains (List[str], optional): Domains to include in the search.
+            exclude_domains (List[str], optional): Domains to exclude from the search.
+            start_crawl_date (str, optional): Only links crawled after this date.
+            end_crawl_date (str, optional): Only links crawled before this date.
+            start_published_date (str, optional): Only links published after this date.
+            end_published_date (str, optional): Only links published before this date.
+            include_text (List[str], optional): Strings that must appear in the page text.
+            exclude_text (List[str], optional): Strings that must not appear in the page text.
+            type (SearchType, optional): Search type - 'auto' (default), 'fast',
+                'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'.
+            category (Category, optional): Data category to focus on.
+            flags (List[str], optional): Experimental flags for Exa usage.
+            moderation (bool, optional): If True, the search results will be moderated for safety.
+            user_location (str, optional): Two-letter ISO country code of the user (e.g. US).
+            additional_queries (List[str], optional): Alternative query formulations for deep search.
+            system_prompt (str, optional): Instructions that guide the search process and streamed synthesis.
+            output_schema (DeepOutputSchema, optional): Search output schema for structured synthesis.
+
+        Returns:
+            AsyncStreamSearchResponse: An async iterator yielding OpenAI-style streaming chunks.
+
+        Examples:
+            >>> async_exa = AsyncExa(api_key="your-api-key")
+            >>> stream = await async_exa.stream_search(
+            ...     "What are the latest battery breakthroughs?",
+            ...     type="auto"
+            ... )
+            >>> async for chunk in stream:
+            ...     if chunk.content:
+            ...         print(chunk.content, end="", flush=True)
+        """
+        options = {k: v for k, v in locals().items() if k != "self" and v is not None}
+
+        if contents is False:
+            options.pop("contents", None)
+        elif contents is None and "contents" not in options:
+            options["contents"] = {"text": {"max_characters": DEFAULT_MAX_CHARACTERS}}
+        elif contents is not None:
+            options["contents"] = contents
+
+        validate_search_options(options, SEARCH_OPTIONS_TYPES)
+        options = to_camel_case(options, skip_keys=["output_schema"])
+        options["stream"] = True
+        raw_response = await self.async_request("/search", options)
+        return AsyncStreamSearchResponse(raw_response)
 
     async def search_and_contents(self, query: str, **kwargs):
         """

--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -261,12 +261,19 @@ Category = Literal[
 SearchType = Literal[
     "auto",
     "fast",
+    "deep-lite",
     "deep",
     "deep-reasoning",
     "neural",
     "instant",
 ]
-"""Search type that determines the search algorithm. 'auto' (default) automatically selects the best approach, 'fast' prioritizes speed, 'deep' is light deep search, 'deep-reasoning' is base deep search, 'neural' uses embedding-based semantic search, and 'instant' uses low-latency neural search."""
+"""Search type that determines the search algorithm.
+
+'auto' (default) automatically selects the best approach, 'fast' prioritizes
+speed, 'deep-lite', 'deep', and 'deep-reasoning' are deep-search variants,
+'neural' uses embedding-based semantic search, and 'instant' uses low-latency
+neural search.
+"""
 
 
 class DeepTextOutputSchema(TypedDict, total=False):
@@ -285,7 +292,7 @@ class DeepObjectOutputSchema(TypedDict, total=False):
 
 
 DeepOutputSchema = Union[DeepTextOutputSchema, DeepObjectOutputSchema]
-"""Deep search output schema.
+"""Search output schema.
 
 - ``{"type": "text", "description": ...}`` returns plain text in ``output.content``.
 - ``{"type": "object", ...}`` returns structured JSON in ``output.content``.
@@ -318,16 +325,16 @@ SEARCH_OPTIONS_TYPES = {
     "type": [
         SearchType,
         str,
-    ],  # Search type: 'auto', 'fast', 'deep', 'deep-reasoning', 'neural', or 'instant' (Default: auto)
+    ],  # Search type: 'auto', 'fast', 'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant' (Default: auto)
     "category": [Category],  # A data category to focus on.
     "flags": [list],  # Experimental flags array for Exa usage.
     "moderation": [bool],  # If true, moderate search results for safety.
     "contents": [dict, bool],  # Options for retrieving page contents
     "additional_queries": [
         list
-    ],  # Alternative query formulations for deep search variants (max 5). Only used when type is deep/deep-reasoning.
-    "system_prompt": [str],  # Deep-search-only instructions for search planning and final synthesis.
-    "output_schema": [dict],  # Deep output schema: {"type":"text"} or {"type":"object", ...}
+    ],  # Alternative query formulations for deep search variants (max 5). Only used when type is deep-lite/deep/deep-reasoning.
+    "system_prompt": [str],  # Instructions for search planning and final synthesis across all search types.
+    "output_schema": [dict],  # Search output schema: {"type":"text"} or {"type":"object", ...}
 }
 
 FIND_SIMILAR_OPTIONS_TYPES = {
@@ -1225,7 +1232,9 @@ class SearchResponse(Generic[T]):
         resolved_search_type (str, optional): 'neural' or 'keyword' if auto.
         auto_date (str, optional): A date for filtering if autoprompt found one.
         context (str, optional): Deprecated. Combined context string when requested via contents.context. Use highlights or text instead.
-        output (DeepSearchOutput, optional): Deep search synthesized output object containing content and field-level grounding.
+        output (DeepSearchOutput, optional): Search synthesized output object returned
+            when output_schema is provided, containing content and field-level
+            grounding.
         statuses (List[ContentStatus], optional): Status list from get_contents.
         cost_dollars (CostDollars, optional): Cost breakdown.
         search_time (float, optional): Time taken for the search in milliseconds.
@@ -1275,7 +1284,7 @@ DeepSearchOutputGroundingConfidence = Literal["low", "medium", "high"]
 
 @dataclass
 class DeepSearchOutputGrounding:
-    """Grounding metadata for one field in deep-search synthesized output."""
+    """Grounding metadata for one field in search synthesized output."""
 
     field: str
     citations: List[DeepSearchOutputGroundingCitation]
@@ -1284,14 +1293,14 @@ class DeepSearchOutputGrounding:
 
 @dataclass
 class DeepSearchOutput:
-    """Deep-search synthesized output payload."""
+    """Search synthesized output payload."""
 
     content: Union[str, dict[str, Any]]
     grounding: List[DeepSearchOutputGrounding]
 
 
 def parse_deep_search_output(raw: Any) -> Optional[DeepSearchOutput]:
-    """Parse deep-search output into a typed object.
+    """Parse search output into a typed object.
 
     Args:
         raw: Raw `output` field from API response.
@@ -1537,24 +1546,25 @@ class Exa:
             end_published_date (str, optional): Only links published before this date.
             include_text (List[str], optional): Strings that must appear in the page text.
             exclude_text (List[str], optional): Strings that must not appear in the page text.
-            type (SearchType, optional): Search type - 'auto' (default), 'fast', 'deep', 'deep-reasoning', 'neural', or 'instant'.
+            type (SearchType, optional): Search type - 'auto' (default), 'fast',
+                'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'.
             category (Category, optional): Data category to focus on (e.g. 'company', 'news', 'research paper').
             flags (List[str], optional): Experimental flags for Exa usage.
             moderation (bool, optional): If True, the search results will be moderated for safety.
             user_location (str, optional): Two-letter ISO country code of the user (e.g. US).
             additional_queries (List[str], optional): Alternative query formulations for deep search to skip
                 automatic LLM-based query expansion. Max 5 queries. Only applicable when type is
-                'deep' or 'deep-reasoning'.
+                'deep-lite', 'deep', or 'deep-reasoning'.
                 Example: ["machine learning", "ML algorithms", "neural networks"]
-            system_prompt (str, optional): Deep-search-only instructions that guide both the
-                search process and the final returned result. Use this to prefer certain sources,
-                emphasize novelty, avoid duplicates, or constrain the response style.
-                Only applicable when type is 'deep' or 'deep-reasoning'.
-            output_schema (DeepOutputSchema, optional): Deep output schema for deep search.
+            system_prompt (str, optional): Instructions that guide both the search process and
+                the final returned result. Use this to prefer certain sources, emphasize novelty,
+                avoid duplicates, or constrain the response style. Supported for all search types.
+            output_schema (DeepOutputSchema, optional): Search output schema for structured
+                synthesis. When provided, the API returns synthesized output in ``output``.
                 Use ``{"type": "text", "description": ...}`` for plain text output or
                 ``{"type": "object", "properties": ..., "required": ...}`` for structured JSON.
                 For object schemas, max nesting depth is 2 and max total properties is 10.
-                Only applicable when type is 'deep' or 'deep-reasoning'.
+                Supported for all search types.
 
         Returns:
             SearchResponse: The response containing search results, etc.
@@ -2588,24 +2598,25 @@ class AsyncExa(Exa):
             end_published_date (str, optional): Only links published before this date.
             include_text (List[str], optional): Strings that must appear in the page text.
             exclude_text (List[str], optional): Strings that must not appear in the page text.
-            type (SearchType, optional): Search type - 'auto' (default), 'fast', 'deep', 'deep-reasoning', 'neural', or 'instant'.
+            type (SearchType, optional): Search type - 'auto' (default), 'fast',
+                'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'.
             category (Category, optional): Data category to focus on (e.g. 'company', 'news', 'research paper').
             flags (List[str], optional): Experimental flags for Exa usage.
             moderation (bool, optional): If True, the search results will be moderated for safety.
             user_location (str, optional): Two-letter ISO country code of the user (e.g. US).
             additional_queries (List[str], optional): Alternative query formulations for deep search to skip
                 automatic LLM-based query expansion. Max 5 queries. Only applicable when type is
-                'deep' or 'deep-reasoning'.
+                'deep-lite', 'deep', or 'deep-reasoning'.
                 Example: ["machine learning", "ML algorithms", "neural networks"]
-            system_prompt (str, optional): Deep-search-only instructions that guide both the
-                search process and the final returned result. Use this to prefer certain sources,
-                emphasize novelty, avoid duplicates, or constrain the response style.
-                Only applicable when type is 'deep' or 'deep-reasoning'.
-            output_schema (DeepOutputSchema, optional): Deep output schema for deep search.
+            system_prompt (str, optional): Instructions that guide both the search process and
+                the final returned result. Use this to prefer certain sources, emphasize novelty,
+                avoid duplicates, or constrain the response style. Supported for all search types.
+            output_schema (DeepOutputSchema, optional): Search output schema for structured
+                synthesis. When provided, the API returns synthesized output in ``output``.
                 Use ``{"type": "text", "description": ...}`` for plain text output or
                 ``{"type": "object", "properties": ..., "required": ...}`` for structured JSON.
                 For object schemas, max nesting depth is 2 and max total properties is 10.
-                Only applicable when type is 'deep' or 'deep-reasoning'.
+                Supported for all search types.
 
         Returns:
             SearchResponse: The response containing search results, etc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.10.2"
+version = "2.10.3"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.10.2"
+version = "2.10.3"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.10.3"
+version = "2.11.0"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.10.3"
+version = "2.11.0"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.10.3",
+    version="2.11.0",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.10.2",
+    version="2.10.3",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/unit/test_search_api.py
+++ b/tests/unit/test_search_api.py
@@ -13,6 +13,34 @@ def _have_real_key() -> bool:
     return API_KEY != "test-key" and len(API_KEY) > 10
 
 
+class _FakeStreamResponse:
+    def __init__(self, lines: list[str], status_code: int = 200):
+        self._lines = lines
+        self.status_code = status_code
+        self.text = ""
+
+    def iter_lines(self):
+        for line in self._lines:
+            yield line.encode("utf-8")
+
+    def close(self):
+        return None
+
+
+class _FakeAsyncStreamResponse:
+    def __init__(self, lines: list[str], status_code: int = 200):
+        self._lines = lines
+        self.status_code = status_code
+        self.text = ""
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+    def close(self):
+        return None
+
+
 ########################################
 # Offline unit tests (no network)
 ########################################
@@ -274,6 +302,47 @@ def test_search_accepts_deep_lite_additional_queries_offline():
         ]
 
 
+def test_search_rejects_stream_flag_offline():
+    """Test search(stream=True) points callers to stream_search."""
+    exa = Exa(API_KEY)
+
+    with pytest.raises(ValueError, match="Please use `stream_search"):
+        exa.search("streaming query", stream=True)
+
+
+def test_stream_search_streams_openai_style_chunks_offline():
+    """Test stream_search forwards stream=true and yields parsed chunks."""
+    exa = Exa(API_KEY)
+    mock_stream_response = _FakeStreamResponse(
+        [
+            'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+            'data: {"citations":[{"id":"1","url":"http://example.com","title":"Example"}]}',
+        ]
+    )
+
+    with patch.object(exa, "request", return_value=mock_stream_response) as mock_request:
+        stream = exa.stream_search(
+            "streaming query",
+            type="auto",
+            system_prompt="Be concise",
+            output_schema={"type": "text", "description": "Short answer"},
+        )
+        chunks = list(stream)
+
+        assert len(chunks) == 2
+        assert chunks[0].content == "Hello"
+        assert chunks[1].citations is not None
+        assert chunks[1].citations[0].url == "http://example.com"
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "/search"
+        options = call_args[0][1]
+        assert options["stream"] is True
+        assert options["type"] == "auto"
+        assert options["systemPrompt"] == "Be concise"
+        assert options["outputSchema"]["type"] == "text"
+
+
 @pytest.mark.asyncio
 async def test_async_search_accepts_deepv3_params_offline():
     """Test async deep-reasoning search accepts output_schema params."""
@@ -410,6 +479,51 @@ async def test_async_search_accepts_deep_lite_additional_queries_offline():
             "neural networks",
             "AI models",
         ]
+
+
+@pytest.mark.asyncio
+async def test_async_search_rejects_stream_flag_offline():
+    """Test async search(stream=True) points callers to stream_search."""
+    ax = AsyncExa(API_KEY)
+
+    with pytest.raises(ValueError, match="Please use `stream_search"):
+        await ax.search("streaming query", stream=True)
+
+
+@pytest.mark.asyncio
+async def test_async_stream_search_streams_openai_style_chunks_offline():
+    """Test async stream_search forwards stream=true and yields parsed chunks."""
+    ax = AsyncExa(API_KEY)
+    mock_stream_response = _FakeAsyncStreamResponse(
+        [
+            'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+            'data: {"citations":[{"id":"1","url":"http://example.com","title":"Example"}]}',
+        ]
+    )
+
+    with patch.object(
+        ax, "async_request", new=AsyncMock(return_value=mock_stream_response)
+    ) as mock_async_request:
+        stream = await ax.stream_search(
+            "streaming query",
+            type="auto",
+            system_prompt="Be concise",
+            output_schema={"type": "text", "description": "Short answer"},
+        )
+        chunks = [chunk async for chunk in stream]
+
+        assert len(chunks) == 2
+        assert chunks[0].content == "Hello"
+        assert chunks[1].citations is not None
+        assert chunks[1].citations[0].url == "http://example.com"
+
+        call_args = mock_async_request.call_args
+        assert call_args[0][0] == "/search"
+        options = call_args[0][1]
+        assert options["stream"] is True
+        assert options["type"] == "auto"
+        assert options["systemPrompt"] == "Be concise"
+        assert options["outputSchema"]["type"] == "text"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_search_api.py
+++ b/tests/unit/test_search_api.py
@@ -166,12 +166,61 @@ def test_search_accepts_deep_reasoning_params_offline():
         assert "answerText" not in options["outputSchema"]["properties"]
 
 
-def test_search_accepts_deep_system_prompt_offline():
-    """Test deep search accepts system_prompt and forwards it as camelCase."""
+def test_search_accepts_output_schema_on_fast_search_offline():
+    """Test non-deep search accepts output_schema and returns parsed output."""
     exa = Exa(API_KEY)
     mock_response = {
         "results": [
-            {"url": "http://example.com", "id": "1", "title": "Deep Search Result"}
+            {"url": "http://example.com", "id": "1", "title": "Fast Search Result"}
+        ],
+        "output": {
+            "content": {"summary": "Fast search synthesis"},
+            "grounding": [
+                {
+                    "field": "summary",
+                    "citations": [
+                        {"url": "http://example.com", "title": "Fast Search Result"}
+                    ],
+                    "confidence": "high",
+                }
+            ],
+        },
+        "costDollars": {"total": 0.002},
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string"},
+        },
+        "required": ["summary"],
+    }
+
+    with patch.object(exa, "request", return_value=mock_response) as mock_request:
+        resp = exa.search(
+            "machine learning",
+            type="fast",
+            output_schema=output_schema,
+            num_results=5,
+        )
+        assert isinstance(resp, exa_api.SearchResponse)
+        assert resp.output is not None
+        assert resp.output.content == {"summary": "Fast search synthesis"}
+        assert resp.output.grounding[0].field == "summary"
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "/search"
+        options = call_args[0][1]
+        assert options["type"] == "fast"
+        assert options["outputSchema"]["properties"]["summary"]["type"] == "string"
+
+
+def test_search_accepts_system_prompt_on_auto_search_offline():
+    """Test non-deep search accepts system_prompt and forwards it as camelCase."""
+    exa = Exa(API_KEY)
+    mock_response = {
+        "results": [
+            {"url": "http://example.com", "id": "1", "title": "Auto Search Result"}
         ],
         "costDollars": {"total": 0.002},
     }
@@ -179,7 +228,7 @@ def test_search_accepts_deep_system_prompt_offline():
     with patch.object(exa, "request", return_value=mock_response) as mock_request:
         resp = exa.search(
             "compare recent model launches",
-            type="deep-reasoning",
+            type="auto",
             system_prompt="Prefer official sources and avoid duplicate results",
         )
         assert isinstance(resp, exa_api.SearchResponse)
@@ -187,11 +236,42 @@ def test_search_accepts_deep_system_prompt_offline():
         call_args = mock_request.call_args
         assert call_args[0][0] == "/search"
         options = call_args[0][1]
-        assert options["type"] == "deep-reasoning"
+        assert options["type"] == "auto"
         assert (
             options["systemPrompt"]
             == "Prefer official sources and avoid duplicate results"
         )
+
+
+def test_search_accepts_deep_lite_additional_queries_offline():
+    """Test deep-lite search accepts additional_queries and forwards them."""
+    exa = Exa(API_KEY)
+    mock_response = {
+        "results": [
+            {"url": "http://example.com", "id": "1", "title": "Deep Lite Result"}
+        ],
+        "costDollars": {"total": 0.002},
+    }
+
+    with patch.object(exa, "request", return_value=mock_response) as mock_request:
+        resp = exa.search(
+            "machine learning",
+            type="deep-lite",
+            additional_queries=["ML algorithms", "neural networks", "AI models"],
+            num_results=5,
+        )
+        assert isinstance(resp, exa_api.SearchResponse)
+
+        call_args = mock_request.call_args
+        assert call_args[0][0] == "/search"
+        options = call_args[0][1]
+        assert options["type"] == "deep-lite"
+        assert "additionalQueries" in options
+        assert options["additionalQueries"] == [
+            "ML algorithms",
+            "neural networks",
+            "AI models",
+        ]
 
 
 @pytest.mark.asyncio
@@ -229,8 +309,82 @@ async def test_async_search_accepts_deepv3_params_offline():
 
 
 @pytest.mark.asyncio
-async def test_async_search_accepts_deep_system_prompt_offline():
-    """Test async deep search accepts system_prompt and forwards it as camelCase."""
+async def test_async_search_accepts_output_schema_on_fast_search_offline():
+    """Test async non-deep search accepts output_schema and returns parsed output."""
+    ax = AsyncExa(API_KEY)
+    mock_response = {
+        "results": [{"url": "http://example.com", "id": "1", "title": "Async Result"}],
+        "output": {
+            "content": {"summary": "Async fast synthesis"},
+            "grounding": [
+                {
+                    "field": "summary",
+                    "citations": [{"url": "http://example.com", "title": "Async Result"}],
+                    "confidence": "high",
+                }
+            ],
+        },
+        "costDollars": {"total": 0.001},
+    }
+
+    output_schema = {
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string"},
+        },
+    }
+
+    with patch.object(
+        ax, "async_request", new=AsyncMock(return_value=mock_response)
+    ) as mock_async_request:
+        resp = await ax.search(
+            "async search query",
+            type="fast",
+            output_schema=output_schema,
+        )
+        assert isinstance(resp, exa_api.SearchResponse)
+        assert resp.output is not None
+        assert resp.output.content == {"summary": "Async fast synthesis"}
+
+        call_args = mock_async_request.call_args
+        assert call_args[0][0] == "/search"
+        options = call_args[0][1]
+        assert options["type"] == "fast"
+        assert options["outputSchema"]["properties"]["summary"]["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_async_search_accepts_system_prompt_on_auto_search_offline():
+    """Test async non-deep search accepts system_prompt and forwards it as camelCase."""
+    ax = AsyncExa(API_KEY)
+    mock_response = {
+        "results": [{"url": "http://example.com", "id": "1", "title": "Async Result"}],
+        "costDollars": {"total": 0.001},
+    }
+
+    with patch.object(
+        ax, "async_request", new=AsyncMock(return_value=mock_response)
+    ) as mock_async_request:
+        resp = await ax.search(
+            "async search query",
+            type="auto",
+            system_prompt="Prefer official sources and avoid duplicate results",
+        )
+        assert isinstance(resp, exa_api.SearchResponse)
+
+        call_args = mock_async_request.call_args
+        assert call_args[0][0] == "/search"
+        options = call_args[0][1]
+        assert options["type"] == "auto"
+        assert (
+            options["systemPrompt"]
+            == "Prefer official sources and avoid duplicate results"
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_search_accepts_deep_lite_additional_queries_offline():
+    """Test async deep-lite search accepts additional_queries."""
     ax = AsyncExa(API_KEY)
     mock_response = {
         "results": [{"url": "http://example.com", "id": "1", "title": "Async Result"}],
@@ -242,19 +396,20 @@ async def test_async_search_accepts_deep_system_prompt_offline():
     ) as mock_async_request:
         resp = await ax.search(
             "async deep query",
-            type="deep",
-            system_prompt="Prefer official sources and avoid duplicate results",
+            type="deep-lite",
+            additional_queries=["ML algorithms", "neural networks", "AI models"],
         )
         assert isinstance(resp, exa_api.SearchResponse)
 
         call_args = mock_async_request.call_args
         assert call_args[0][0] == "/search"
         options = call_args[0][1]
-        assert options["type"] == "deep"
-        assert (
-            options["systemPrompt"]
-            == "Prefer official sources and avoid duplicate results"
-        )
+        assert options["type"] == "deep-lite"
+        assert options["additionalQueries"] == [
+            "ML algorithms",
+            "neural networks",
+            "AI models",
+        ]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.10.3"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.10.2"
+version = "2.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## What changed
This updates the Python SDK search surface so `system_prompt` and `output_schema` are supported across all search types, adds `deep-lite` as a deep search variant, and documents that `output` is returned when `output_schema` is provided.

## Why
The search API now supports these parameters across every search type instead of only deep and deep-reasoning, and it adds `deep-lite` alongside the existing deep variants.

## Impact
Python SDK consumers can now pass `system_prompt` and `output_schema` on non-deep searches, use `deep-lite`, and rely on the typed `output` field when structured output is requested.

## Validation
- `./.venv/bin/pytest tests/unit/test_search_api.py -q`
- `./.venv/bin/python scripts/generate_docs.py > docs/python-sdk-specification.mdx`
- `uv lock`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-py/pull/195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
