### PR TITLE
feat(exa-py): add deep-max search type

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Deep search variants that also support `additional_queries`:
 - `deep-lite`
 - `deep`
 - `deep-reasoning`
+- `deep-max`
 
 ## Contents
 

--- a/docs/python-sdk-specification.mdx
+++ b/docs/python-sdk-specification.mdx
@@ -80,12 +80,12 @@ deep_result = exa.search(
 | end_published_date | Optional[str] | Only links published before this date. | None |
 | include_text | Optional[List[str]] | Strings that must appear in the page text. | None |
 | exclude_text | Optional[List[str]] | Strings that must not appear in the page text. | None |
-| type | Optional[Union[[SearchType](#searchtype), str]] | Search type - 'auto' (default), 'fast', 'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'. | None |
+| type | Optional[Union[[SearchType](#searchtype), str]] | Search type - 'auto' (default), 'fast', 'deep-lite', 'deep', 'deep-reasoning', 'deep-max', 'neural', or 'instant'. | None |
 | category | Optional[[Category](#category)] | Data category to focus on (e.g. 'company', 'news', 'research paper'). | None |
 | flags | Optional[List[str]] | Experimental flags for Exa usage. | None |
 | moderation | Optional[bool] | If True, the search results will be moderated for safety. | None |
 | user_location | Optional[str] | Two-letter ISO country code of the user (e.g. US). | None |
-| additional_queries | Optional[List[str]] | Alternative query formulations for deep search to skip automatic LLM-based query expansion. Max 5 queries. Only applicable when type is 'deep-lite', 'deep', or 'deep-reasoning'. Example: ["machine learning", "ML algorithms", "neural networks"] | None |
+| additional_queries | Optional[List[str]] | Alternative query formulations for deep search to skip automatic LLM-based query expansion. Max 5 queries. Only applicable when type is 'deep-lite', 'deep', 'deep-reasoning', or 'deep-max'. Example: ["machine learning", "ML algorithms", "neural networks"] | None |
 | system_prompt | Optional[str] | Instructions that guide both the search process and the final returned result. Use this to prefer certain sources, emphasize novelty, avoid duplicates, or constrain the response style. Supported for all search types. | None |
 | output_schema | Optional[[DeepOutputSchema](#deepoutputschema)] | Search output schema for structured synthesis. When provided, the API returns synthesized output in ``output``. Use ``{"type": "text", "description": ...}`` for plain text output or ``{"type": "object", "properties": ..., "required": ...}`` for structured JSON. For object schemas, max nesting depth is 2 and max total properties is 10. Supported for all search types. | None |
 
@@ -1947,12 +1947,12 @@ Data category to focus on when searching. Each category returns results speciali
 Search type that determines the search algorithm.
 
 'auto' (default) automatically selects the best approach, 'fast' prioritizes
-speed, 'deep-lite', 'deep', and 'deep-reasoning' are deep-search variants,
-'neural' uses embedding-based semantic search, and 'instant' uses low-latency
-neural search.
+speed, 'deep-lite', 'deep', 'deep-reasoning', and 'deep-max' are deep-search
+variants, 'neural' uses embedding-based semantic search, and 'instant' uses
+low-latency neural search.
 
 
-**Type:** Literal['auto', 'fast', 'deep-lite', 'deep', 'deep-reasoning', 'neural', 'instant']
+**Type:** Literal['auto', 'fast', 'deep-lite', 'deep', 'deep-reasoning', 'deep-max', 'neural', 'instant']
 
 #### `DeepOutputSchema`
 

--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -264,15 +264,16 @@ SearchType = Literal[
     "deep-lite",
     "deep",
     "deep-reasoning",
+    "deep-max",
     "neural",
     "instant",
 ]
 """Search type that determines the search algorithm.
 
 'auto' (default) automatically selects the best approach, 'fast' prioritizes
-speed, 'deep-lite', 'deep', and 'deep-reasoning' are deep-search variants,
-'neural' uses embedding-based semantic search, and 'instant' uses low-latency
-neural search.
+speed, 'deep-lite', 'deep', 'deep-reasoning', and 'deep-max' are deep-search
+variants, 'neural' uses embedding-based semantic search, and 'instant' uses
+low-latency neural search.
 """
 
 
@@ -325,14 +326,14 @@ SEARCH_OPTIONS_TYPES = {
     "type": [
         SearchType,
         str,
-    ],  # Search type: 'auto', 'fast', 'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant' (Default: auto)
+    ],  # Search type: 'auto', 'fast', 'deep-lite', 'deep', 'deep-reasoning', 'deep-max', 'neural', or 'instant' (Default: auto)
     "category": [Category],  # A data category to focus on.
     "flags": [list],  # Experimental flags array for Exa usage.
     "moderation": [bool],  # If true, moderate search results for safety.
     "contents": [dict, bool],  # Options for retrieving page contents
     "additional_queries": [
         list
-    ],  # Alternative query formulations for deep search variants (max 5). Only used when type is deep-lite/deep/deep-reasoning.
+    ],  # Alternative query formulations for deep search variants (max 5). Only used when type is deep-lite/deep/deep-reasoning/deep-max.
     "system_prompt": [str],  # Instructions for search planning and final synthesis across all search types.
     "output_schema": [dict],  # Search output schema: {"type":"text"} or {"type":"object", ...}
     "stream": [bool],  # If true, stream back OpenAI-style chat completion chunks.
@@ -1559,14 +1560,14 @@ class Exa:
             include_text (List[str], optional): Strings that must appear in the page text.
             exclude_text (List[str], optional): Strings that must not appear in the page text.
             type (SearchType, optional): Search type - 'auto' (default), 'fast',
-                'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'.
+                'deep-lite', 'deep', 'deep-reasoning', 'deep-max', 'neural', or 'instant'.
             category (Category, optional): Data category to focus on (e.g. 'company', 'news', 'research paper').
             flags (List[str], optional): Experimental flags for Exa usage.
             moderation (bool, optional): If True, the search results will be moderated for safety.
             user_location (str, optional): Two-letter ISO country code of the user (e.g. US).
             additional_queries (List[str], optional): Alternative query formulations for deep search to skip
                 automatic LLM-based query expansion. Max 5 queries. Only applicable when type is
-                'deep-lite', 'deep', or 'deep-reasoning'.
+                'deep-lite', 'deep', 'deep-reasoning', or 'deep-max'.
                 Example: ["machine learning", "ML algorithms", "neural networks"]
             system_prompt (str, optional): Instructions that guide both the search process and
                 the final returned result. Use this to prefer certain sources, emphasize novelty,
@@ -1695,7 +1696,7 @@ class Exa:
             include_text (List[str], optional): Strings that must appear in the page text.
             exclude_text (List[str], optional): Strings that must not appear in the page text.
             type (SearchType, optional): Search type - 'auto' (default), 'fast',
-                'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'.
+                'deep-lite', 'deep', 'deep-reasoning', 'deep-max', 'neural', or 'instant'.
             category (Category, optional): Data category to focus on.
             flags (List[str], optional): Experimental flags for Exa usage.
             moderation (bool, optional): If True, the search results will be moderated for safety.
@@ -2701,14 +2702,14 @@ class AsyncExa(Exa):
             include_text (List[str], optional): Strings that must appear in the page text.
             exclude_text (List[str], optional): Strings that must not appear in the page text.
             type (SearchType, optional): Search type - 'auto' (default), 'fast',
-                'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'.
+                'deep-lite', 'deep', 'deep-reasoning', 'deep-max', 'neural', or 'instant'.
             category (Category, optional): Data category to focus on (e.g. 'company', 'news', 'research paper').
             flags (List[str], optional): Experimental flags for Exa usage.
             moderation (bool, optional): If True, the search results will be moderated for safety.
             user_location (str, optional): Two-letter ISO country code of the user (e.g. US).
             additional_queries (List[str], optional): Alternative query formulations for deep search to skip
                 automatic LLM-based query expansion. Max 5 queries. Only applicable when type is
-                'deep-lite', 'deep', or 'deep-reasoning'.
+                'deep-lite', 'deep', 'deep-reasoning', or 'deep-max'.
                 Example: ["machine learning", "ML algorithms", "neural networks"]
             system_prompt (str, optional): Instructions that guide both the search process and
                 the final returned result. Use this to prefer certain sources, emphasize novelty,
@@ -2834,7 +2835,7 @@ class AsyncExa(Exa):
             include_text (List[str], optional): Strings that must appear in the page text.
             exclude_text (List[str], optional): Strings that must not appear in the page text.
             type (SearchType, optional): Search type - 'auto' (default), 'fast',
-                'deep-lite', 'deep', 'deep-reasoning', 'neural', or 'instant'.
+                'deep-lite', 'deep', 'deep-reasoning', 'deep-max', 'neural', or 'instant'.
             category (Category, optional): Data category to focus on.
             flags (List[str], optional): Experimental flags for Exa usage.
             moderation (bool, optional): If True, the search results will be moderated for safety.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.11.0"
+version = "2.11.1"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.11.0"
+version = "2.11.1"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.11.0",
+    version="2.11.1",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 
 [[package]]
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.11.0"
+version = "2.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary

Adds `deep-max` to the `SearchType` literal and updates all associated docstrings/comments. This aligns the Python SDK with the API, which already accepts `deep-max` as a deep search variant.

Changes:
- `SearchType` Literal: added `"deep-max"`
- `SEARCH_OPTIONS_TYPES` inline comments: updated type list and `additional_queries` applicability
- All 4 search method docstrings (`Exa.search`, `Exa.stream_search`, `AsyncExa.search`, `AsyncExa.stream_search`): updated type and additional_queries docs
- README: added `deep-max` to deep search variants list

**Updates since last revision:**
- Bumped version to `2.11.1` in all 3 locations (`pyproject.toml` ×2, `setup.py`) per CLAUDE.md rules
- Ran `uv lock` to sync lockfile
- Regenerated `docs/python-sdk-specification.mdx` via `scripts/generate_docs.py`

## Review & Testing Checklist for Human

- [ ] **Confirm `deep-max` should be a public SDK type.** The dashboard UI currently normalizes `deep-max` → `deep-reasoning` via `normalizeDeepModelSelection()` in `SearchSection.tsx`, and the playground dropdown doesn't expose it. Vulcan accepts it and routes it to the deep pipeline with `effort: "max"`, and it's in `exa-spec.yaml` + OpenAPI spec — but the UI treatment as "legacy" is worth reconciling before shipping this.
- [ ] Verify the regenerated `docs/python-sdk-specification.mdx` looks correct (should now list `deep-max` in SearchType literal and parameter tables)
- [ ] Spot-check that `2.11.1` version bump is the right increment (no other unreleased changes on master that would warrant a different version)

### Notes
No behavioral code changes — purely type definitions and documentation. `SearchType` accepts `Union[SearchType, str]` at runtime so `deep-max` already worked as a raw string, but wasn't in the Literal for type-checking/autocomplete.

Companion PR: exa-js#160 adds `deep-max` to the JS SDK's `DeepSearchType`.

Link to Devin session: https://app.devin.ai/sessions/37d00c74a58c46af92847ccdad46699e
Requested by: @maxwbuckley
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-py/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
