### PR TITLE
feat: add crawl_date field to search result objects

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -730,6 +730,7 @@ class _Result:
         subpages (List[_Result], optional): Subpages of main page
         extras (Dict, optional): Additional metadata; e.g. links, images.
         entities (List[Entity], optional): Structured entity data for company or person searches.
+        crawl_date (str, optional): The date the page was last crawled (if available).
     """
 
     url: str
@@ -743,6 +744,7 @@ class _Result:
     subpages: Optional[List[_Result]] = None
     extras: Optional[Dict] = None
     entities: Optional[List[Entity]] = None
+    crawl_date: Optional[str] = None
 
     def __init__(
         self,
@@ -757,6 +759,7 @@ class _Result:
         subpages=None,
         extras=None,
         entities=None,
+        crawl_date=None,
     ):
         self.url = url
         self.id = id
@@ -769,6 +772,7 @@ class _Result:
         self.subpages = subpages
         self.extras = extras
         self.entities = entities
+        self.crawl_date = crawl_date
 
     def __str__(self):
         result = (
@@ -782,6 +786,7 @@ class _Result:
             f"Favicon: {self.favicon}\n"
             f"Extras: {self.extras}\n"
             f"Subpages: {self.subpages}\n"
+            f"Crawl Date: {self.crawl_date}\n"
         )
         if self.entities:
             entities_str = "\n".join(
@@ -822,6 +827,7 @@ class Result(_Result):
         subpages=None,
         extras=None,
         entities=None,
+        crawl_date=None,
         text=None,
         summary=None,
         highlights=None,
@@ -839,6 +845,7 @@ class Result(_Result):
             subpages,
             extras,
             entities,
+            crawl_date,
         )
         self.text = text
         self.summary = summary
@@ -879,6 +886,7 @@ class ResultWithText(_Result):
         subpages=None,
         extras=None,
         entities=None,
+        crawl_date=None,
         text="",
     ):
         super().__init__(
@@ -893,6 +901,7 @@ class ResultWithText(_Result):
             subpages,
             extras,
             entities,
+            crawl_date,
         )
         self.text = text
 
@@ -925,6 +934,7 @@ class ResultWithSummary(_Result):
         subpages=None,
         extras=None,
         entities=None,
+        crawl_date=None,
         summary="",
     ):
         super().__init__(
@@ -939,6 +949,7 @@ class ResultWithSummary(_Result):
             subpages,
             extras,
             entities,
+            crawl_date,
         )
         self.summary = summary
 
@@ -973,6 +984,7 @@ class ResultWithTextAndSummary(_Result):
         subpages=None,
         extras=None,
         entities=None,
+        crawl_date=None,
         text="",
         summary="",
     ):
@@ -988,6 +1000,7 @@ class ResultWithTextAndSummary(_Result):
             subpages,
             extras,
             entities,
+            crawl_date,
         )
         self.text = text
         self.summary = summary
@@ -1639,6 +1652,7 @@ class Exa:
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),
@@ -1802,6 +1816,7 @@ class Exa:
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),
@@ -1968,6 +1983,7 @@ class Exa:
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),
@@ -2067,6 +2083,7 @@ class Exa:
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),
@@ -2282,6 +2299,7 @@ class Exa:
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),
@@ -2778,6 +2796,7 @@ class AsyncExa(Exa):
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),
@@ -2940,6 +2959,7 @@ class AsyncExa(Exa):
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),
@@ -3042,6 +3062,7 @@ class AsyncExa(Exa):
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),
@@ -3147,6 +3168,7 @@ class AsyncExa(Exa):
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),
@@ -3226,6 +3248,7 @@ class AsyncExa(Exa):
                     favicon=snake_result.get("favicon"),
                     subpages=snake_result.get("subpages"),
                     extras=snake_result.get("extras"),
+                    crawl_date=snake_result.get("crawl_date"),
                     text=snake_result.get("text"),
                     summary=snake_result.get("summary"),
                     highlights=snake_result.get("highlights"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.11.0"
+version = "2.12.0"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.11.0"
+version = "2.12.0"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.11.0",
+    version="2.12.0",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/unit/test_search_api.py
+++ b/tests/unit/test_search_api.py
@@ -707,6 +707,90 @@ def test_search_accepts_highlights_with_max_characters_offline():
         assert highlights_opts["maxCharacters"] == 500
 
 
+def test_crawl_date_parsing_offline():
+    """Test that Result properly parses crawl_date from API response."""
+    exa = Exa(API_KEY)
+    mock_response = {
+        "results": [
+            {
+                "url": "http://example.com",
+                "id": "1",
+                "title": "Test",
+                "text": "Sample text",
+                "crawlDate": "2026-04-14T12:31:28.000Z",
+            }
+        ],
+        "costDollars": {"total": 0.001},
+    }
+
+    with patch.object(exa, "request", return_value=mock_response):
+        resp = exa.search("test query", contents={"text": True}, num_results=1)
+        assert isinstance(resp, exa_api.SearchResponse)
+        assert resp.results[0].crawl_date == "2026-04-14T12:31:28.000Z"
+
+
+def test_crawl_date_defaults_to_none_offline():
+    """Test that crawl_date is None when not present in API response."""
+    exa = Exa(API_KEY)
+    mock_response = {
+        "results": [
+            {
+                "url": "http://example.com",
+                "id": "1",
+                "title": "Test",
+            }
+        ],
+        "costDollars": {"total": 0.001},
+    }
+
+    with patch.object(exa, "request", return_value=mock_response):
+        resp = exa.search("test query", num_results=1)
+        assert isinstance(resp, exa_api.SearchResponse)
+        assert resp.results[0].crawl_date is None
+
+
+def test_crawl_date_on_result_dataclass_offline():
+    """Test that crawl_date can be set directly on Result objects."""
+    result = exa_api.Result(
+        url="http://example.com",
+        id="test-id",
+        title="Test Title",
+        crawl_date="2026-04-14T12:31:28.000Z",
+    )
+    assert result.crawl_date == "2026-04-14T12:31:28.000Z"
+
+    result_no_crawl = exa_api.Result(
+        url="http://example.com",
+        id="test-id",
+        title="Test Title",
+    )
+    assert result_no_crawl.crawl_date is None
+
+
+@pytest.mark.asyncio
+async def test_async_crawl_date_parsing_offline():
+    """Test that AsyncExa properly parses crawl_date from API response."""
+    ax = AsyncExa(API_KEY)
+    mock_response = {
+        "results": [
+            {
+                "url": "http://example.com",
+                "id": "1",
+                "title": "Test",
+                "crawlDate": "2026-04-14T12:31:28.000Z",
+            }
+        ],
+        "costDollars": {"total": 0.001},
+    }
+
+    with patch.object(
+        ax, "async_request", new=AsyncMock(return_value=mock_response)
+    ):
+        resp = await ax.search("test query", num_results=1)
+        assert isinstance(resp, exa_api.SearchResponse)
+        assert resp.results[0].crawl_date == "2026-04-14T12:31:28.000Z"
+
+
 def test_search_and_contents_with_highlights_offline():
     """Test deprecated search_and_contents method with highlights."""
     exa = Exa(API_KEY)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 
 [[package]]
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary

The Exa API returns `crawlDate` on search results (when the `include_crawl_date` feature flag is enabled for an account), but the Python SDK was silently dropping it during response parsing. The `camel_to_snake` converter correctly transforms it to `crawl_date`, but it was never extracted into the Result objects.

This PR adds `crawl_date: Optional[str]` as a first-class field on `_Result` and propagates it through all subclasses (`Result`, `ResultWithText`, `ResultWithSummary`, `ResultWithTextAndSummary`) and all 10 response-parsing paths in both `Exa` and `AsyncExa`.

After this change, users can access `result.crawl_date` directly:
```python
results = exa.search_and_contents("query", text=True)
for r in results.results:
    print(r.crawl_date)  # e.g. "2026-04-14T12:31:28.000Z"
```

Version bumped from `2.11.0` → `2.12.0` in all 3 locations (`pyproject.toml` ×2, `setup.py`) and `uv lock` run per `CLAUDE.md` requirements.

## Review & Testing Checklist for Human

- [ ] **Live API verification**: The 4 new unit tests use mocked responses. Verify with a real API call using an account that has `include_crawl_date` enabled that `result.crawl_date` is a non-None ISO 8601 string. Accounts without the flag should see `None`.
- [ ] **All 10 parsing paths covered**: Confirm `crawl_date=snake_result.get("crawl_date")` appears in all Result construction sites — `search`, `search_and_contents`, `get_contents`, `find_similar`, `find_similar_and_contents` (×2 for sync/async).
- [ ] **Positional arg compatibility**: `crawl_date` is inserted after `entities` in the `__init__` parameter order. All internal construction uses keyword arguments, but any external code constructing Result objects with positional args would need updating.

**Suggested test plan**: Run `exa.search_and_contents("test query", text=True)` with an API key that has `include_crawl_date` enabled and verify `result.crawl_date` is populated. Then repeat with an account without the flag and confirm it returns `None`.

### Notes
- The field is `Optional[str]` and defaults to `None`, so this is fully backward-compatible — accounts without the feature flag will simply see `None`.
- 4 new offline unit tests added: parsing from mocked camelCase response, default `None` when absent, direct dataclass construction, and async parsing.

Link to Devin session: https://app.devin.ai/sessions/9bb4195afb254be09f8dc587eaa63a86
Requested by: @louiswalsh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-py/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
