### PR TITLE
[codex] Add maxPeoplePerCompany to Websets Python SDK

### DIFF
--- a/exa_py/websets/types.py
+++ b/exa_py/websets/types.py
@@ -195,6 +195,10 @@ class CreateWebsetSearchParameters(ExaBaseModel):
     """
     Sources (existing imports or websets) to exclude from search results. Any results found within these sources will be omitted to prevent finding them during search.
     """
+    max_people_per_company: Annotated[Optional[PositiveInt], Field(alias='maxPeoplePerCompany')] = None
+    """
+    Optional soft cap for people searches. When set, the search will try to include at most this many matching people from the same current employer company.
+    """
     scope: Optional[List[ScopeItem]] = None
     """
     Limit the search to specific sources (existing imports or websets). Any results found within these sources matching the search criteria will be included in the Webset.
@@ -956,6 +960,10 @@ class CreateWebsetParametersSearch(ExaBaseModel):
     exclude: Optional[List[ExcludeItem]] = None
     """
     Sources (existing imports or websets) to exclude from search results. Any results found within these sources will be omitted to prevent finding them during search.
+    """
+    max_people_per_company: Annotated[Optional[PositiveInt], Field(alias='maxPeoplePerCompany')] = None
+    """
+    Optional soft cap for people searches. When set, the search will try to include at most this many matching people from the same current employer company.
     """
     scope: Optional[List[ScopeItem]] = None
     """
@@ -1824,6 +1832,10 @@ class WebsetSearch(ExaBaseModel):
     count: PositiveInt
     """
     The number of results the search will attempt to find. The actual number of results may be less than this number depending on the search complexity.
+    """
+    max_people_per_company: Annotated[Optional[PositiveInt], Field(alias='maxPeoplePerCompany')] = None
+    """
+    The soft cap requested for matching people from the same current employer company, or null when no cap was requested.
     """
     behavior: Optional[WebsetSearchBehavior] = WebsetSearchBehavior.override
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.12.0"
+version = "2.12.1"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.12.0"
+version = "2.12.1"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.12.0",
+    version="2.12.1",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/unit/test_websets.py
+++ b/tests/unit/test_websets.py
@@ -15,6 +15,7 @@ from exa_py.websets.types import (
     UpdateWebsetRequest,
     CreateWebsetParameters,
     CreateWebsetParametersSearch,
+    CreateWebsetSearchParameters,
     CreateEnrichmentParameters,
     Format,
 )
@@ -215,7 +216,8 @@ def test_request_body_case_conversion(websets_client, parent_mock):
         external_id="test-id",
         search=CreateWebsetParametersSearch(
             query="test query",
-            count=10
+            count=10,
+            max_people_per_company=2
         ),
         metadata={"snake_case_key": "value"}
     )
@@ -226,7 +228,8 @@ def test_request_body_case_conversion(websets_client, parent_mock):
     assert actual_data == {
         "search": {
             "query": "test query",
-            "count": 10
+            "count": 10,
+            "maxPeoplePerCompany": 2
         },
         "externalId": "test-id",  # This should be camelCase in the request
         "metadata": {"snake_case_key": "value"}  # metadata preserved original case
@@ -887,22 +890,35 @@ async def test_async_searches_client_create(async_websets_client, async_parent_m
         "query": "test query",
         "criteria": [],
         "count": 10,
+        "maxPeoplePerCompany": 2,
         "progress": {"total": 100, "completed": 0, "found": 5, "completion": 0.0},
         "createdAt": "2023-01-01T00:00:00Z",
         "updatedAt": "2023-01-01T00:00:00Z"
     }
     async_parent_mock.async_request.return_value = search_response
     
-    params = {"query": "test query", "count": 10}
+    params = CreateWebsetSearchParameters(
+        query="test query",
+        count=10,
+        max_people_per_company=2,
+    )
     result = await async_websets_client.searches.create(webset_id="ws_123", params=params)
+
+    expected_data = {
+        "query": "test query",
+        "count": 10,
+        "maxPeoplePerCompany": 2,
+        "behavior": "override",
+    }
     
     async_parent_mock.async_request.assert_called_once_with(
         "/websets/v0/websets/ws_123/searches",
-        data=params,
+        data=expected_data,
         method="POST",
         params=None
     )
     assert result.id == "search_123"
+    assert result.max_people_per_company == 2
     assert result.query == "test query"
 
 @pytest.mark.asyncio
@@ -954,5 +970,3 @@ async def test_async_concurrent_requests(async_websets_client, async_parent_mock
     assert len(results) == 3
     assert all(result.id == "ws_123" for result in results)
     assert async_parent_mock.async_request.call_count == 3
-
- 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 
 [[package]]
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.12.0"
+version = "2.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary

Expose the new Websets `maxPeoplePerCompany` parameter in the Python SDK models.

- Adds typed `max_people_per_company` fields with `maxPeoplePerCompany` aliases for create/search request models.
- Adds the field to Webset search responses.
- Adds request serialization and response parsing test coverage.
- Bumps the SDK patch version to `2.12.1` and updates `uv.lock`.

## Validation

- `uv run pytest tests/unit/test_websets.py`
- `uv run python -m compileall exa_py/websets`
- `git diff --check`