### PR TITLE
Make deprecated SDK surfaces obvious

### DIFF
--- a/docs/python-sdk-specification.mdx
+++ b/docs/python-sdk-specification.mdx
@@ -70,7 +70,7 @@ deep_result = exa.search(
 | --------- | ---- | ----------- | ------- |
 | query | str | The query string. | Required |
 | stream | Optional[bool] | If True, stream the synthesized search response. Use ``stream_search(...)`` instead of ``search(..., stream=True)``. | `False` |
-| contents | Optional[Union[[ContentsOptions](#contentsoptions), Literal[False]]] | Options for retrieving page contents. Defaults to `{"text": {"maxCharacters": 10000}`}. Use False to disable contents. See [ContentsOptions](#contentsoptions) for available options (text, highlights, summary, etc.). Note: The ``context`` option is deprecated; use ``highlights`` or ``text`` instead. | None |
+| contents | Optional[Union[[ContentsOptions](#contentsoptions), Literal[False]]] | Options for retrieving page contents. Defaults to `{"text": {"maxCharacters": 10000}`}. Use False to disable contents. See [ContentsOptions](#contentsoptions) for available options (text, highlights, summary, etc.). DEPRECATED FIELD WARNING: ``contents.context`` is deprecated; use ``highlights`` or ``text`` instead. | None |
 | num_results | Optional[int] | Number of search results to return. Default 10. | None |
 | include_domains | Optional[List[str]] | Domains to include in the search. | None |
 | exclude_domains | Optional[List[str]] | Domains to exclude from the search. | None |
@@ -129,6 +129,7 @@ deep_result = exa.search(
 | subpages | Optional[List[[_Result](#_result)]] | Subpages of main page |
 | extras | Optional[Dict] | Additional metadata; e.g. links, images. |
 | entities | Optional[List[[Entity](#entity)]] | Structured entity data for company or person searches. |
+| crawl_date | Optional[str] | The date the page was last crawled (if available). |
 
 ## `find_similar` Method
 
@@ -151,7 +152,7 @@ similar_results = exa.find_similar(
 | Parameter | Type | Description | Default |
 | --------- | ---- | ----------- | ------- |
 | url | str | The URL to find similar pages for. | Required |
-| contents | Optional[Union[[ContentsOptions](#contentsoptions), Literal[False]]] | Options for retrieving page contents. Defaults to `{"text": {"maxCharacters": 10000}`}. Use False to disable contents. See [ContentsOptions](#contentsoptions) for available options (text, highlights, summary, etc.). | None |
+| contents | Optional[Union[[ContentsOptions](#contentsoptions), Literal[False]]] | Options for retrieving page contents. Defaults to `{"text": {"maxCharacters": 10000}`}. Use False to disable contents. See [ContentsOptions](#contentsoptions) for available options (text, highlights, summary, etc.). DEPRECATED FIELD WARNING: ``contents.context`` is deprecated; use ``highlights`` or ``text`` instead. | None |
 | num_results | Optional[int] | Number of results to return. Default is None (server default). | None |
 | include_domains | Optional[List[str]] | Domains to include in the search. | None |
 | exclude_domains | Optional[List[str]] | Domains to exclude from the search. | None |
@@ -204,6 +205,7 @@ similar_results = exa.find_similar(
 | subpages | Optional[List[[_Result](#_result)]] | Subpages of main page |
 | extras | Optional[Dict] | Additional metadata; e.g. links, images. |
 | entities | Optional[List[[Entity](#entity)]] | Structured entity data for company or person searches. |
+| crawl_date | Optional[str] | The date the page was last crawled (if available). |
 
 ## `get_contents` Method
 
@@ -258,6 +260,7 @@ contents = exa.get_contents([
 | subpages | Optional[List[[_Result](#_result)]] | Subpages of main page |
 | extras | Optional[Dict] | Additional metadata; e.g. links, images. |
 | entities | Optional[List[[Entity](#entity)]] | Structured entity data for company or person searches. |
+| crawl_date | Optional[str] | The date the page was last crawled (if available). |
 
 ## `answer` Method
 
@@ -1141,12 +1144,12 @@ A class representing the options that you can specify when requesting highlights
 | ----- | ---- | ----------- |
 | query | str | The query string for highlight generation. Highlights will be biased towards this query. |
 | max_characters | int | The maximum number of characters to return for highlights. Default: None (server default). |
-| num_sentences | int | Deprecated. Use max_characters instead. The number of sentences per highlight. |
-| highlights_per_url | int | Deprecated. Use max_characters instead. The number of highlights to return per URL. |
+| num_sentences | int | DEPRECATED FIELD - do not use in new code. Use max_characters instead. Kept only for backward compatibility. |
+| highlights_per_url | int | DEPRECATED FIELD - do not use in new code. Use max_characters instead. Kept only for backward compatibility. |
 
 #### `ContextContentsOptions`
 
-Options for retrieving aggregated context from a set of search results.
+DEPRECATED TYPE: Options for legacy aggregated context from search results.
 
 .. deprecated::
     Use ``highlights`` or ``text`` instead. The ``context`` option is deprecated
@@ -1154,7 +1157,7 @@ Options for retrieving aggregated context from a set of search results.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| max_characters | int | The maximum number of characters to include in the context string. |
+| max_characters | int | DEPRECATED FIELD - only applies to deprecated contents.context. Use highlights.max_characters or text.max_characters instead. |
 
 #### `ExtrasOptions`
 
@@ -1177,7 +1180,7 @@ max_characters=10000 is returned by default.
 | text | Union[[TextContentsOptions](#textcontentsoptions), Literal[True]] | Options for text extraction, or True for defaults. |
 | highlights | Union[[HighlightsContentsOptions](#highlightscontentsoptions), Literal[True]] | Options for highlight extraction, or True for defaults. |
 | summary | Union[[SummaryContentsOptions](#summarycontentsoptions), Literal[True]] | Options for summary generation, or True for defaults. |
-| context | Union[[ContextContentsOptions](#contextcontentsoptions), Literal[True]] | Deprecated. Use `highlights` or `text` instead. Will be removed in a future version. |
+| context | Union[[ContextContentsOptions](#contextcontentsoptions), Literal[True]] | DEPRECATED FIELD - do not use in new code. Use `highlights` or `text` instead. Will be removed in a future version. |
 | max_age_hours | int | Maximum age of cached content in hours. If content is older, it will be fetched fresh. Special values: 0 = always fetch fresh content, -1 = never fetch fresh (use cached content only). Example: 168 = fetch fresh for pages older than 7 days. |
 | subpages | int | Number of subpages to crawl. |
 | subpage_target | Union[str, List[str]] | Target subpage path(s) to crawl. |
@@ -1208,7 +1211,7 @@ Deep search output schema for structured JSON object output.
 
 #### `JSONSchema`
 
-Represents a JSON Schema definition used for structured summary output.
+DEPRECATED TYPE: Legacy JSON Schema TypedDict for structured summary output.
 
 .. deprecated:: 1.15.0
     Use Pydantic models or dict[str, Any] directly instead.
@@ -1279,6 +1282,7 @@ A class representing the base fields of a search result.
 | subpages | Optional[List[[_Result](#_result)]] | Subpages of main page |
 | extras | Optional[Dict] | Additional metadata; e.g. links, images. |
 | entities | Optional[List[[Entity](#entity)]] | Structured entity data for company or person searches. |
+| crawl_date | Optional[str] | The date the page was last crawled (if available). |
 
 #### `Result`
 
@@ -1297,6 +1301,7 @@ A class representing a search result with optional text, summary, and highlights
 | subpages | Optional[List[[_Result](#_result)]] | Subpages of main page |
 | extras | Optional[Dict] | Additional metadata; e.g. links, images. |
 | entities | Optional[List[[Entity](#entity)]] | Structured entity data for company or person searches. |
+| crawl_date | Optional[str] | The date the page was last crawled (if available). |
 | text | Optional[str] | The text content of the page. |
 | summary | Optional[str] | A summary of the page content. |
 | highlights | Optional[List[str]] | Relevant sentences from the page. |
@@ -1319,6 +1324,7 @@ A class representing a search result with text present.
 | subpages | Optional[List[[_Result](#_result)]] | Subpages of main page |
 | extras | Optional[Dict] | Additional metadata; e.g. links, images. |
 | entities | Optional[List[[Entity](#entity)]] | Structured entity data for company or person searches. |
+| crawl_date | Optional[str] | The date the page was last crawled (if available). |
 | text | str | The text of the search result page. |
 
 #### `ResultWithSummary`
@@ -1338,6 +1344,7 @@ A class representing a search result with summary present.
 | subpages | Optional[List[[_Result](#_result)]] | Subpages of main page |
 | extras | Optional[Dict] | Additional metadata; e.g. links, images. |
 | entities | Optional[List[[Entity](#entity)]] | Structured entity data for company or person searches. |
+| crawl_date | Optional[str] | The date the page was last crawled (if available). |
 | summary | str | - |
 
 #### `ResultWithTextAndSummary`
@@ -1357,6 +1364,7 @@ A class representing a search result with text and summary present.
 | subpages | Optional[List[[_Result](#_result)]] | Subpages of main page |
 | extras | Optional[Dict] | Additional metadata; e.g. links, images. |
 | entities | Optional[List[[Entity](#entity)]] | Structured entity data for company or person searches. |
+| crawl_date | Optional[str] | The date the page was last crawled (if available). |
 | text | str | - |
 | summary | str | - |
 
@@ -1427,7 +1435,7 @@ A class representing the response for a search operation.
 | results | List[T] | A list of search results. |
 | resolved_search_type | Optional[str] | 'neural' or 'keyword' if auto. |
 | auto_date | Optional[str] | A date for filtering if autoprompt found one. |
-| context | Optional[str] | Deprecated. Combined context string when requested via contents.context. Use highlights or text instead. |
+| context | Optional[str] | DEPRECATED FIELD - do not use in new code. Combined context string from legacy context responses. Use highlights, text, or output instead. |
 | output | Optional['[DeepSearchOutput](#deepsearchoutput)'] | Search synthesized output object returned when output_schema is provided, containing content and field-level grounding. |
 | statuses | Optional[List[[ContentStatus](#contentstatus)]] | Status list from get_contents. |
 | cost_dollars | Optional[[CostDollars](#costdollars)] | Cost breakdown. |
@@ -1742,8 +1750,8 @@ Options for highlights extraction in monitor results.
 | ----- | ---- | ----------- |
 | query | Optional[str] | - |
 | max_characters | Optional[int] | - |
-| num_sentences | Optional[int] | - |
-| highlights_per_url | Optional[int] | - |
+| num_sentences | Optional[int] | DEPRECATED FIELD - do not use in new code. Use max_characters/maxCharacters instead. |
+| highlights_per_url | Optional[int] | DEPRECATED FIELD - do not use in new code. Use max_characters/maxCharacters instead. |
 
 #### `SearchMonitorSummaryContents`
 
@@ -1768,7 +1776,8 @@ Options for additional data extraction in monitor results.
 Options for retrieving page contents in monitor results.
 
 Mirrors the main search ContentsOptions. Text, highlights, and summary
-accept either True (for defaults) or an options object.
+accept either True (for defaults) or an options object. The context field is
+deprecated and kept only for backward compatibility.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
@@ -1776,7 +1785,7 @@ accept either True (for defaults) or an options object.
 | highlights | Optional[Union[bool, [SearchMonitorHighlightsContents](#searchmonitorhighlightscontents)]] | - |
 | summary | Optional[Union[bool, [SearchMonitorSummaryContents](#searchmonitorsummarycontents)]] | - |
 | extras | Optional[[SearchMonitorExtrasContents](#searchmonitorextrascontents)] | - |
-| context | Optional[Union[bool, Dict[str, Any]]] | - |
+| context | Optional[Union[bool, Dict[str, Any]]] | DEPRECATED FIELD - do not use in new code. Use highlights or text instead. |
 | livecrawl | Optional[[LIVECRAWL_OPTION](#livecrawl_option)] | - |
 | livecrawl_timeout | Optional[int] | - |
 | max_age_hours | Optional[int] | - |

--- a/docs/python-sdk-specification.mdx
+++ b/docs/python-sdk-specification.mdx
@@ -133,6 +133,11 @@ deep_result = exa.search(
 
 ## `find_similar` Method
 
+DEPRECATED METHOD: find_similar()/findSimilar is deprecated. Use search() instead.
+
+Migration:
+    Use search("pages similar to " + url) instead of find_similar(url).
+
 Finds similar pages to a given URL, potentially with domain filters and date filters.
 
 By default, returns text contents with 10,000 max characters. Use contents=False to opt-out.
@@ -140,10 +145,10 @@ By default, returns text contents with 10,000 max characters. Use contents=False
 ### Input Example
 
 ```python
-similar_results = exa.find_similar(
-    "miniclip.com",
+url = "https://www.miniclip.com/games/en/"
+similar_results = exa.search(
+    f"pages similar to {url}",
     num_results=2,
-    exclude_source_domain=True
 )
 ```
 
@@ -1170,7 +1175,7 @@ A class representing additional extraction fields (e.g. links, images)
 
 #### `ContentsOptions`
 
-Options for retrieving page contents in search and find_similar methods.
+Options for retrieving page contents in search and legacy find_similar methods.
 
 All fields are optional. If no content options are specified, text with
 max_characters=10000 is returned by default.

--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -29,7 +29,7 @@ import requests
 from openai import OpenAI
 from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
 from openai.types.chat_model import ChatModel
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, deprecated
 
 from exa_py.utils import (
     ExaOpenAICompletion,
@@ -363,7 +363,7 @@ CONTENTS_OPTIONS_TYPES = {
     "text": [dict, bool],
     "summary": [dict, bool],
     "highlights": [dict, bool],
-    "context": [dict, bool],
+    "context": [dict, bool],  # DEPRECATED FIELD: use highlights or text instead.
     "metadata": [dict, bool],
     "livecrawl_timeout": [int],
     "livecrawl": [LIVECRAWL_OPTIONS],
@@ -466,8 +466,9 @@ class TextContentsOptions(TypedDict, total=False):
     exclude_sections: List[SECTION_TAG]
 
 
+@deprecated("Use Pydantic models or dict[str, Any] directly instead. JSONSchema will be removed in a future version.")
 class JSONSchema(TypedDict, total=False):
-    """Represents a JSON Schema definition used for structured summary output.
+    """DEPRECATED TYPE: Legacy JSON Schema TypedDict for structured summary output.
 
     .. deprecated:: 1.15.0
         Use Pydantic models or dict[str, Any] directly instead.
@@ -512,28 +513,31 @@ class HighlightsContentsOptions(TypedDict, total=False):
     Attributes:
         query (str): The query string for highlight generation. Highlights will be biased towards this query.
         max_characters (int): The maximum number of characters to return for highlights. Default: None (server default).
-        num_sentences (int): Deprecated. Use max_characters instead. The number of sentences per highlight.
-        highlights_per_url (int): Deprecated. Use max_characters instead. The number of highlights to return per URL.
+        num_sentences (int): DEPRECATED FIELD - do not use in new code. Use max_characters instead.
+            Kept only for backward compatibility.
+        highlights_per_url (int): DEPRECATED FIELD - do not use in new code. Use max_characters instead.
+            Kept only for backward compatibility.
     """
 
     query: str
     max_characters: int
-    num_sentences: int
-    highlights_per_url: int
+    num_sentences: int  # DEPRECATED FIELD: use max_characters. Do not use in new code.
+    highlights_per_url: int  # DEPRECATED FIELD: use max_characters. Do not use in new code.
 
 
 class ContextContentsOptions(TypedDict, total=False):
-    """Options for retrieving aggregated context from a set of search results.
+    """DEPRECATED TYPE: Options for legacy aggregated context from search results.
 
     .. deprecated::
         Use ``highlights`` or ``text`` instead. The ``context`` option is deprecated
         and will be removed in a future version.
 
     Attributes:
-        max_characters (int): The maximum number of characters to include in the context string.
+        max_characters (int): DEPRECATED FIELD - only applies to deprecated contents.context.
+            Use highlights.max_characters or text.max_characters instead.
     """
 
-    max_characters: int
+    max_characters: int  # DEPRECATED FIELD: only for contents.context. Use highlights/text instead.
 
 
 class ExtrasOptions(TypedDict, total=False):
@@ -553,7 +557,8 @@ class ContentsOptions(TypedDict, total=False):
         text (TextContentsOptions | True): Options for text extraction, or True for defaults.
         highlights (HighlightsContentsOptions | True): Options for highlight extraction, or True for defaults.
         summary (SummaryContentsOptions | True): Options for summary generation, or True for defaults.
-        context (ContextContentsOptions | True): Deprecated. Use ``highlights`` or ``text`` instead. Will be removed in a future version.
+        context (ContextContentsOptions | True): DEPRECATED FIELD - do not use in new code.
+            Use ``highlights`` or ``text`` instead. Will be removed in a future version.
         max_age_hours (int): Maximum age of cached content in hours. If content is older, it will be
             fetched fresh. Special values: 0 = always fetch fresh content,
             -1 = never fetch fresh (use cached content only). Example: 168 = fetch fresh for pages older than 7 days.
@@ -565,7 +570,7 @@ class ContentsOptions(TypedDict, total=False):
     text: Union[TextContentsOptions, Literal[True]]
     highlights: Union[HighlightsContentsOptions, Literal[True]]
     summary: Union[SummaryContentsOptions, Literal[True]]
-    context: Union[ContextContentsOptions, Literal[True]]
+    context: Union[ContextContentsOptions, Literal[True]]  # DEPRECATED FIELD: use highlights or text.
     livecrawl: LIVECRAWL_OPTIONS
     livecrawl_timeout: int
     max_age_hours: int
@@ -1253,7 +1258,8 @@ class SearchResponse(Generic[T]):
         results (List[Result]): A list of search results.
         resolved_search_type (str, optional): 'neural' or 'keyword' if auto.
         auto_date (str, optional): A date for filtering if autoprompt found one.
-        context (str, optional): Deprecated. Combined context string when requested via contents.context. Use highlights or text instead.
+        context (str, optional): DEPRECATED FIELD - do not use in new code.
+            Combined context string from legacy context responses. Use highlights, text, or output instead.
         output (DeepSearchOutput, optional): Search synthesized output object returned
             when output_schema is provided, containing content and field-level
             grounding.
@@ -1265,7 +1271,7 @@ class SearchResponse(Generic[T]):
     results: List[T]
     resolved_search_type: Optional[str]
     auto_date: Optional[str]
-    context: Optional[str] = None
+    context: Optional[str] = None  # DEPRECATED FIELD: legacy context response. Use highlights/text/output.
     output: Optional["DeepSearchOutput"] = None
     statuses: Optional[List[ContentStatus]] = None
     cost_dollars: Optional[CostDollars] = None
@@ -1273,7 +1279,7 @@ class SearchResponse(Generic[T]):
 
     def __str__(self):
         output = "\n\n".join(str(result) for result in self.results)
-        if self.context:
+        if self.context:  # DEPRECATED FIELD: legacy context response.
             output += f"\nContext: {self.context}"
         if self.output is not None:
             output += f"\nOutput: {self.output}"
@@ -1561,7 +1567,8 @@ class Exa:
             contents (ContentsOptions | False, optional): Options for retrieving page contents.
                 Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
                 See ContentsOptions for available options (text, highlights, summary, etc.).
-                Note: The ``context`` option is deprecated; use ``highlights`` or ``text`` instead.
+                DEPRECATED FIELD WARNING: ``contents.context`` is deprecated;
+                use ``highlights`` or ``text`` instead.
             num_results (int, optional): Number of search results to return. Default 10.
             include_domains (List[str], optional): Domains to include in the search.
             exclude_domains (List[str], optional): Domains to exclude from the search.
@@ -1664,7 +1671,7 @@ class Exa:
             results,
             data["resolvedSearchType"] if "resolvedSearchType" in data else None,
             data["autoDate"] if "autoDate" in data else None,
-            context=data.get("context"),
+            context=data.get("context"),  # DEPRECATED FIELD: legacy context response.
             output=parse_deep_search_output(data.get("output")),
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
@@ -1699,6 +1706,8 @@ class Exa:
             query (str): The query string.
             contents (ContentsOptions | False, optional): Options for retrieving page contents.
                 Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
+                DEPRECATED FIELD WARNING: ``contents.context`` is deprecated;
+                use ``highlights`` or ``text`` instead.
             num_results (int, optional): Number of search results to return. Default 10.
             include_domains (List[str], optional): Domains to include in the search.
             exclude_domains (List[str], optional): Domains to exclude from the search.
@@ -1747,6 +1756,10 @@ class Exa:
         raw_response = self.request("/search", options)
         return StreamSearchResponse(raw_response)
 
+    @deprecated(
+        "search_and_contents() is deprecated. Use search() instead; "
+        "search() returns text contents by default."
+    )
     def search_and_contents(self, query: str, **kwargs):
         """
         DEPRECATED: Use search() instead. The search() method now returns text contents by default.
@@ -1788,7 +1801,7 @@ class Exa:
                 "text",
                 "summary",
                 "highlights",
-                "context",
+                "context",  # DEPRECATED FIELD: accepted only for backward compatibility.
                 "subpages",
                 "subpage_target",
                 "livecrawl",
@@ -1828,7 +1841,7 @@ class Exa:
             results,
             data.get("resolvedSearchType"),
             data.get("autoDate"),
-            context=data.get("context"),
+            context=data.get("context"),  # DEPRECATED FIELD: legacy context response.
             output=parse_deep_search_output(data.get("output")),
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
@@ -1995,7 +2008,7 @@ class Exa:
             results,
             data.get("resolvedSearchType"),
             data.get("autoDate"),
-            context=data.get("context"),
+            context=data.get("context"),  # DEPRECATED FIELD: legacy context response.
             cost_dollars=cost_dollars,
             statuses=statuses,
             search_time=data.get("searchTime"),
@@ -2028,6 +2041,8 @@ class Exa:
             contents (ContentsOptions | False, optional): Options for retrieving page contents.
                 Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
                 See ContentsOptions for available options (text, highlights, summary, etc.).
+                DEPRECATED FIELD WARNING: ``contents.context`` is deprecated;
+                use ``highlights`` or ``text`` instead.
             num_results (int, optional): Number of results to return. Default is None (server default).
             include_domains (List[str], optional): Domains to include in the search.
             exclude_domains (List[str], optional): Domains to exclude from the search.
@@ -2100,6 +2115,10 @@ class Exa:
         )
 
     @overload
+    @deprecated(
+        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
+        "find_similar() returns text contents by default."
+    )
     def find_similar_and_contents(
         self,
         url: str,
@@ -2126,33 +2145,10 @@ class Exa:
     ) -> SearchResponse[ResultWithText]: ...
 
     @overload
-    def find_similar_and_contents(
-        self,
-        url: str,
-        *,
-        text: Union[TextContentsOptions, Literal[True]],
-        num_results: Optional[int] = None,
-        include_domains: Optional[List[str]] = None,
-        exclude_domains: Optional[List[str]] = None,
-        start_crawl_date: Optional[str] = None,
-        end_crawl_date: Optional[str] = None,
-        start_published_date: Optional[str] = None,
-        end_published_date: Optional[str] = None,
-        include_text: Optional[List[str]] = None,
-        exclude_text: Optional[List[str]] = None,
-        exclude_source_domain: Optional[bool] = None,
-        category: Optional[Category] = None,
-        flags: Optional[List[str]] = None,
-        livecrawl_timeout: Optional[int] = None,
-        livecrawl: Optional[LIVECRAWL_OPTIONS] = None,
-        max_age_hours: Optional[int] = None,
-        filter_empty_results: Optional[bool] = None,
-        subpages: Optional[int] = None,
-        subpage_target: Optional[Union[str, List[str]]] = None,
-        extras: Optional[ExtrasOptions] = None,
-    ) -> SearchResponse[ResultWithText]: ...
-
-    @overload
+    @deprecated(
+        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
+        "find_similar() returns text contents by default."
+    )
     def find_similar_and_contents(
         self,
         url: str,
@@ -2180,6 +2176,41 @@ class Exa:
     ) -> SearchResponse[ResultWithText]: ...
 
     @overload
+    @deprecated(
+        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
+        "find_similar() returns text contents by default."
+    )
+    def find_similar_and_contents(
+        self,
+        url: str,
+        *,
+        text: Union[TextContentsOptions, Literal[True]],
+        num_results: Optional[int] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        start_crawl_date: Optional[str] = None,
+        end_crawl_date: Optional[str] = None,
+        start_published_date: Optional[str] = None,
+        end_published_date: Optional[str] = None,
+        include_text: Optional[List[str]] = None,
+        exclude_text: Optional[List[str]] = None,
+        exclude_source_domain: Optional[bool] = None,
+        category: Optional[Category] = None,
+        flags: Optional[List[str]] = None,
+        livecrawl_timeout: Optional[int] = None,
+        livecrawl: Optional[LIVECRAWL_OPTIONS] = None,
+        max_age_hours: Optional[int] = None,
+        filter_empty_results: Optional[bool] = None,
+        subpages: Optional[int] = None,
+        subpage_target: Optional[Union[str, List[str]]] = None,
+        extras: Optional[ExtrasOptions] = None,
+    ) -> SearchResponse[ResultWithText]: ...
+
+    @overload
+    @deprecated(
+        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
+        "find_similar() returns text contents by default."
+    )
     def find_similar_and_contents(
         self,
         url: str,
@@ -2207,6 +2238,10 @@ class Exa:
     ) -> SearchResponse[ResultWithSummary]: ...
 
     @overload
+    @deprecated(
+        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
+        "find_similar() returns text contents by default."
+    )
     def find_similar_and_contents(
         self,
         url: str,
@@ -2234,6 +2269,10 @@ class Exa:
         extras: Optional[ExtrasOptions] = None,
     ) -> SearchResponse[ResultWithTextAndSummary]: ...
 
+    @deprecated(
+        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
+        "find_similar() returns text contents by default."
+    )
     def find_similar_and_contents(self, url: str, **kwargs):
         """
         DEPRECATED: Use find_similar() instead. The find_similar() method now returns text contents by default.
@@ -2271,7 +2310,7 @@ class Exa:
                 "text",
                 "summary",
                 "highlights",
-                "context",
+                "context",  # DEPRECATED FIELD: accepted only for backward compatibility.
                 "subpages",
                 "subpage_target",
                 "livecrawl",
@@ -2311,7 +2350,7 @@ class Exa:
             results,
             data.get("resolvedSearchType"),
             data.get("autoDate"),
-            context=data.get("context"),
+            context=data.get("context"),  # DEPRECATED FIELD: legacy context response.
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
         )
@@ -2708,7 +2747,8 @@ class AsyncExa(Exa):
             contents (ContentsOptions | False, optional): Options for retrieving page contents.
                 Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
                 See ContentsOptions for available options (text, highlights, summary, etc.).
-                Note: The ``context`` option is deprecated; use ``highlights`` or ``text`` instead.
+                DEPRECATED FIELD WARNING: ``contents.context`` is deprecated;
+                use ``highlights`` or ``text`` instead.
             num_results (int, optional): Number of search results to return. Default 10.
             include_domains (List[str], optional): Domains to include in the search.
             exclude_domains (List[str], optional): Domains to exclude from the search.
@@ -2808,7 +2848,7 @@ class AsyncExa(Exa):
             results,
             data.get("resolvedSearchType"),
             data.get("autoDate"),
-            context=data.get("context"),
+            context=data.get("context"),  # DEPRECATED FIELD: legacy context response.
             output=parse_deep_search_output(data.get("output")),
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
@@ -2843,6 +2883,8 @@ class AsyncExa(Exa):
             query (str): The query string.
             contents (ContentsOptions | False, optional): Options for retrieving page contents.
                 Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
+                DEPRECATED FIELD WARNING: ``contents.context`` is deprecated;
+                use ``highlights`` or ``text`` instead.
             num_results (int, optional): Number of search results to return. Default 10.
             include_domains (List[str], optional): Domains to include in the search.
             exclude_domains (List[str], optional): Domains to exclude from the search.
@@ -2890,6 +2932,10 @@ class AsyncExa(Exa):
         raw_response = await self.async_request("/search", options)
         return AsyncStreamSearchResponse(raw_response)
 
+    @deprecated(
+        "search_and_contents() is deprecated. Use search() instead; "
+        "search() returns text contents by default."
+    )
     async def search_and_contents(self, query: str, **kwargs):
         """
         DEPRECATED: Use search() instead. The search() method now returns text contents by default.
@@ -2931,7 +2977,7 @@ class AsyncExa(Exa):
                 "text",
                 "summary",
                 "highlights",
-                "context",
+                "context",  # DEPRECATED FIELD: accepted only for backward compatibility.
                 "subpages",
                 "subpage_target",
                 "livecrawl",
@@ -2971,7 +3017,7 @@ class AsyncExa(Exa):
             results,
             data.get("resolvedSearchType"),
             data.get("autoDate"),
-            context=data.get("context"),
+            context=data.get("context"),  # DEPRECATED FIELD: legacy context response.
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
         )
@@ -3074,7 +3120,7 @@ class AsyncExa(Exa):
             results,
             data.get("resolvedSearchType"),
             data.get("autoDate"),
-            context=data.get("context"),
+            context=data.get("context"),  # DEPRECATED FIELD: legacy context response.
             cost_dollars=cost_dollars,
             statuses=statuses,
             search_time=data.get("searchTime"),
@@ -3107,6 +3153,8 @@ class AsyncExa(Exa):
             contents (ContentsOptions | False, optional): Options for retrieving page contents.
                 Defaults to {"text": {"maxCharacters": 10000}}. Use False to disable contents.
                 See ContentsOptions for available options (text, highlights, summary, etc.).
+                DEPRECATED FIELD WARNING: ``contents.context`` is deprecated;
+                use ``highlights`` or ``text`` instead.
             num_results (int, optional): Number of results to return. Default is None (server default).
             include_domains (List[str], optional): Domains to include in the search.
             exclude_domains (List[str], optional): Domains to exclude from the search.
@@ -3184,6 +3232,10 @@ class AsyncExa(Exa):
             search_time=data.get("searchTime"),
         )
 
+    @deprecated(
+        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
+        "find_similar() returns text contents by default."
+    )
     async def find_similar_and_contents(self, url: str, **kwargs):
         """
         DEPRECATED: Use find_similar() instead. The find_similar() method now returns text contents by default.
@@ -3220,7 +3272,7 @@ class AsyncExa(Exa):
                 "text",
                 "summary",
                 "highlights",
-                "context",
+                "context",  # DEPRECATED FIELD: accepted only for backward compatibility.
                 "subpages",
                 "subpage_target",
                 "livecrawl",
@@ -3260,7 +3312,7 @@ class AsyncExa(Exa):
             results,
             data.get("resolvedSearchType"),
             data.get("autoDate"),
-            context=data.get("context"),
+            context=data.get("context"),  # DEPRECATED FIELD: legacy context response.
             cost_dollars=cost_dollars,
             search_time=data.get("searchTime"),
         )

--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -548,7 +548,7 @@ class ExtrasOptions(TypedDict, total=False):
 
 
 class ContentsOptions(TypedDict, total=False):
-    """Options for retrieving page contents in search and find_similar methods.
+    """Options for retrieving page contents in search and legacy find_similar methods.
 
     All fields are optional. If no content options are specified, text with
     max_characters=10000 is returned by default.
@@ -2014,6 +2014,7 @@ class Exa:
             search_time=data.get("searchTime"),
         )
 
+    @deprecated("find_similar()/findSimilar is deprecated. Use search() instead.")
     def find_similar(
         self,
         url: str,
@@ -2032,7 +2033,12 @@ class Exa:
         category: Optional[Category] = None,
         flags: Optional[List[str]] = None,
     ) -> SearchResponse[Result]:
-        """Finds similar pages to a given URL, potentially with domain filters and date filters.
+        """DEPRECATED METHOD: find_similar()/findSimilar is deprecated. Use search() instead.
+
+        Migration:
+            Use search("pages similar to " + url) instead of find_similar(url).
+
+        Finds similar pages to a given URL, potentially with domain filters and date filters.
 
         By default, returns text contents with 10,000 max characters. Use contents=False to opt-out.
 
@@ -2060,10 +2066,10 @@ class Exa:
             SearchResponse[Result]
 
         Examples:
-            similar_results = exa.find_similar(
-                "miniclip.com",
+            url = "https://www.miniclip.com/games/en/"
+            similar_results = exa.search(
+                f"pages similar to {url}",
                 num_results=2,
-                exclude_source_domain=True
             )
         """
         options = {k: v for k, v in locals().items() if k != "self" and v is not None}
@@ -2116,8 +2122,8 @@ class Exa:
 
     @overload
     @deprecated(
-        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
-        "find_similar() returns text contents by default."
+        "find_similar_and_contents() is deprecated. Use search() instead; "
+        "search() returns text contents by default."
     )
     def find_similar_and_contents(
         self,
@@ -2146,39 +2152,8 @@ class Exa:
 
     @overload
     @deprecated(
-        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
-        "find_similar() returns text contents by default."
-    )
-    def find_similar_and_contents(
-        self,
-        url: str,
-        *,
-        text: Union[TextContentsOptions, Literal[True]],
-        num_results: Optional[int] = None,
-        include_domains: Optional[List[str]] = None,
-        exclude_domains: Optional[List[str]] = None,
-        start_crawl_date: Optional[str] = None,
-        end_crawl_date: Optional[str] = None,
-        start_published_date: Optional[str] = None,
-        end_published_date: Optional[str] = None,
-        include_text: Optional[List[str]] = None,
-        exclude_text: Optional[List[str]] = None,
-        exclude_source_domain: Optional[bool] = None,
-        category: Optional[Category] = None,
-        flags: Optional[List[str]] = None,
-        livecrawl_timeout: Optional[int] = None,
-        livecrawl: Optional[LIVECRAWL_OPTIONS] = None,
-        max_age_hours: Optional[int] = None,
-        filter_empty_results: Optional[bool] = None,
-        subpages: Optional[int] = None,
-        subpage_target: Optional[Union[str, List[str]]] = None,
-        extras: Optional[ExtrasOptions] = None,
-    ) -> SearchResponse[ResultWithText]: ...
-
-    @overload
-    @deprecated(
-        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
-        "find_similar() returns text contents by default."
+        "find_similar_and_contents() is deprecated. Use search() instead; "
+        "search() returns text contents by default."
     )
     def find_similar_and_contents(
         self,
@@ -2208,8 +2183,39 @@ class Exa:
 
     @overload
     @deprecated(
-        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
-        "find_similar() returns text contents by default."
+        "find_similar_and_contents() is deprecated. Use search() instead; "
+        "search() returns text contents by default."
+    )
+    def find_similar_and_contents(
+        self,
+        url: str,
+        *,
+        text: Union[TextContentsOptions, Literal[True]],
+        num_results: Optional[int] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        start_crawl_date: Optional[str] = None,
+        end_crawl_date: Optional[str] = None,
+        start_published_date: Optional[str] = None,
+        end_published_date: Optional[str] = None,
+        include_text: Optional[List[str]] = None,
+        exclude_text: Optional[List[str]] = None,
+        exclude_source_domain: Optional[bool] = None,
+        category: Optional[Category] = None,
+        flags: Optional[List[str]] = None,
+        livecrawl_timeout: Optional[int] = None,
+        livecrawl: Optional[LIVECRAWL_OPTIONS] = None,
+        max_age_hours: Optional[int] = None,
+        filter_empty_results: Optional[bool] = None,
+        subpages: Optional[int] = None,
+        subpage_target: Optional[Union[str, List[str]]] = None,
+        extras: Optional[ExtrasOptions] = None,
+    ) -> SearchResponse[ResultWithText]: ...
+
+    @overload
+    @deprecated(
+        "find_similar_and_contents() is deprecated. Use search() instead; "
+        "search() returns text contents by default."
     )
     def find_similar_and_contents(
         self,
@@ -2239,8 +2245,8 @@ class Exa:
 
     @overload
     @deprecated(
-        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
-        "find_similar() returns text contents by default."
+        "find_similar_and_contents() is deprecated. Use search() instead; "
+        "search() returns text contents by default."
     )
     def find_similar_and_contents(
         self,
@@ -2270,17 +2276,17 @@ class Exa:
     ) -> SearchResponse[ResultWithTextAndSummary]: ...
 
     @deprecated(
-        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
-        "find_similar() returns text contents by default."
+        "find_similar_and_contents() is deprecated. Use search() instead; "
+        "search() returns text contents by default."
     )
     def find_similar_and_contents(self, url: str, **kwargs):
         """
-        DEPRECATED: Use find_similar() instead. The find_similar() method now returns text contents by default.
+        DEPRECATED: Use search() instead. The search() method returns text contents by default.
 
         Migration:
-        - find_similar_and_contents(url) → find_similar(url)
-        - find_similar_and_contents(url, text=True) → find_similar(url, contents={"text": True})
-        - find_similar_and_contents(url, summary=True) → find_similar(url, contents={"summary": True})
+        - find_similar_and_contents(url) → search(f"pages similar to {url}")
+        - find_similar_and_contents(url, text=True) → search(f"pages similar to {url}", contents={"text": True})
+        - find_similar_and_contents(url, summary=True) → search(f"pages similar to {url}", contents={"summary": True})
         """
 
         options = {"url": url}
@@ -3126,6 +3132,7 @@ class AsyncExa(Exa):
             search_time=data.get("searchTime"),
         )
 
+    @deprecated("find_similar()/findSimilar is deprecated. Use search() instead.")
     async def find_similar(
         self,
         url: str,
@@ -3144,7 +3151,12 @@ class AsyncExa(Exa):
         category: Optional[Category] = None,
         flags: Optional[List[str]] = None,
     ) -> SearchResponse[Result]:
-        """Finds similar pages to a given URL, potentially with domain filters and date filters.
+        """DEPRECATED METHOD: find_similar()/findSimilar is deprecated. Use search() instead.
+
+        Migration:
+            Use await search("pages similar to " + url) instead of await find_similar(url).
+
+        Finds similar pages to a given URL, potentially with domain filters and date filters.
 
         By default, returns text contents with 10,000 max characters. Use contents=False to opt-out.
 
@@ -3172,16 +3184,16 @@ class AsyncExa(Exa):
             SearchResponse[Result]
 
         Examples:
-            Find similar pages asynchronously:
+            Use async search instead:
             >>> async_exa = AsyncExa(api_key="your-api-key")
-            >>> results = await async_exa.find_similar("https://www.nature.com/articles/s41586-021-03819-2")
+            >>> results = await async_exa.search("pages similar to https://www.nature.com/articles/s41586-021-03819-2")
             >>> print(results.results[0].title)
 
-            Find similar with domain filters:
-            >>> results = await async_exa.find_similar(
-            ...     "https://arxiv.org/abs/2301.00001",
+            Search with domain filters:
+            >>> url = "https://arxiv.org/abs/2301.00001"
+            >>> results = await async_exa.search(
+            ...     f"pages similar to {url}",
             ...     include_domains=["arxiv.org", "openreview.net"],
-            ...     exclude_source_domain=True
             ... )
         """
         options = {k: v for k, v in locals().items() if k != "self" and v is not None}
@@ -3233,17 +3245,17 @@ class AsyncExa(Exa):
         )
 
     @deprecated(
-        "find_similar_and_contents() is deprecated. Use find_similar() instead; "
-        "find_similar() returns text contents by default."
+        "find_similar_and_contents() is deprecated. Use search() instead; "
+        "search() returns text contents by default."
     )
     async def find_similar_and_contents(self, url: str, **kwargs):
         """
-        DEPRECATED: Use find_similar() instead. The find_similar() method now returns text contents by default.
+        DEPRECATED: Use search() instead. The search() method returns text contents by default.
 
         Migration:
-        - find_similar_and_contents(url) → find_similar(url)
-        - find_similar_and_contents(url, text=True) → find_similar(url, contents={"text": True})
-        - find_similar_and_contents(url, summary=True) → find_similar(url, contents={"summary": True})
+        - find_similar_and_contents(url) → search(f"pages similar to {url}")
+        - find_similar_and_contents(url, text=True) → search(f"pages similar to {url}", contents={"text": True})
+        - find_similar_and_contents(url, summary=True) → search(f"pages similar to {url}", contents={"summary": True})
         """
         options = {"url": url}
         for k, v in kwargs.items():

--- a/exa_py/monitors/types.py
+++ b/exa_py/monitors/types.py
@@ -67,8 +67,26 @@ class SearchMonitorHighlightsContents(BaseModel):
 
     query: Optional[str] = None
     max_characters: Optional[int] = Field(default=None, alias="maxCharacters")
-    num_sentences: Optional[int] = Field(default=None, alias="numSentences")
-    highlights_per_url: Optional[int] = Field(default=None, alias="highlightsPerUrl")
+    num_sentences: Optional[int] = Field(
+        default=None,
+        alias="numSentences",  # DEPRECATED FIELD: legacy API key.
+        deprecated=(
+            "DEPRECATED FIELD - do not use in new code. Use max_characters/maxCharacters instead."
+        ),
+        description=(
+            "DEPRECATED FIELD - do not use in new code. Use max_characters/maxCharacters instead."
+        ),
+    )
+    highlights_per_url: Optional[int] = Field(
+        default=None,
+        alias="highlightsPerUrl",  # DEPRECATED FIELD: legacy API key.
+        deprecated=(
+            "DEPRECATED FIELD - do not use in new code. Use max_characters/maxCharacters instead."
+        ),
+        description=(
+            "DEPRECATED FIELD - do not use in new code. Use max_characters/maxCharacters instead."
+        ),
+    )
 
     model_config = {"populate_by_name": True}
 
@@ -95,14 +113,23 @@ class SearchMonitorContents(BaseModel):
     """Options for retrieving page contents in monitor results.
 
     Mirrors the main search ContentsOptions. Text, highlights, and summary
-    accept either True (for defaults) or an options object.
+    accept either True (for defaults) or an options object. The context field is
+    deprecated and kept only for backward compatibility.
     """
 
     text: Optional[Union[bool, SearchMonitorTextContents]] = None
     highlights: Optional[Union[bool, SearchMonitorHighlightsContents]] = None
     summary: Optional[Union[bool, SearchMonitorSummaryContents]] = None
     extras: Optional[SearchMonitorExtrasContents] = None
-    context: Optional[Union[bool, Dict[str, Any]]] = None
+    context: Optional[Union[bool, Dict[str, Any]]] = Field(
+        default=None,
+        deprecated=(
+            "DEPRECATED FIELD - do not use in new code. Use highlights or text instead."
+        ),
+        description=(
+            "DEPRECATED FIELD - do not use in new code. Use highlights or text instead."
+        ),
+    )
     livecrawl: Optional[LIVECRAWL_OPTION] = None
     livecrawl_timeout: Optional[int] = Field(default=None, alias="livecrawlTimeout")
     max_age_hours: Optional[int] = Field(default=None, alias="maxAgeHours")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.12.1"
+version = "2.12.2"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.12.1"
+version = "2.12.2"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/scripts/gen_config.json
+++ b/scripts/gen_config.json
@@ -342,7 +342,7 @@
       {"name": "text", "type": "Union[TextContentsOptions, Literal[True]]", "description": "Options for text extraction, or True for defaults."},
       {"name": "highlights", "type": "Union[HighlightsContentsOptions, Literal[True]]", "description": "Options for highlight extraction, or True for defaults."},
       {"name": "summary", "type": "Union[SummaryContentsOptions, Literal[True]]", "description": "Options for summary generation, or True for defaults."},
-      {"name": "context", "type": "Union[ContextContentsOptions, Literal[True]]", "description": "Deprecated. Use `highlights` or `text` instead. Will be removed in a future version."},
+      {"name": "context", "type": "Union[ContextContentsOptions, Literal[True]]", "description": "DEPRECATED FIELD - do not use in new code. Use `highlights` or `text` instead. Will be removed in a future version."},
       {"name": "max_age_hours", "type": "int", "description": "Maximum age of cached content in hours. If content is older, it will be fetched fresh. Special values: 0 = always fetch fresh content, -1 = never fetch fresh (use cached content only). Example: 168 = fetch fresh for pages older than 7 days."},
       {"name": "subpages", "type": "int", "description": "Number of subpages to crawl."},
       {"name": "subpage_target", "type": "Union[str, List[str]]", "description": "Target subpage path(s) to crawl."},

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -316,6 +316,47 @@ class DocGenerator:
         # Not an Annotated type, return as-is
         return self.get_type_annotation_str(annotation), None
 
+    def extract_field_call_description(self, value: Optional[ast.expr]) -> Optional[str]:
+        """Extract description or deprecation text from a Pydantic Field(...) assignment."""
+        if not isinstance(value, ast.Call):
+            return None
+
+        func_name = ""
+        if isinstance(value.func, ast.Name):
+            func_name = value.func.id
+        elif isinstance(value.func, ast.Attribute):
+            func_name = value.func.attr
+
+        if func_name != "Field":
+            return None
+
+        description = None
+        deprecated_message = None
+
+        for keyword in value.keywords:
+            if keyword.arg == "description" and isinstance(keyword.value, ast.Constant):
+                description = keyword.value.value
+            elif keyword.arg == "deprecated":
+                if isinstance(keyword.value, ast.Constant):
+                    if isinstance(keyword.value.value, str):
+                        deprecated_message = keyword.value.value
+                    elif keyword.value.value is True:
+                        deprecated_message = "DEPRECATED FIELD"
+                elif isinstance(keyword.value, ast.Call) and keyword.value.args:
+                    first_arg = keyword.value.args[0]
+                    if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
+                        deprecated_message = first_arg.value
+
+        if deprecated_message and description:
+            if "DEPRECATED" not in description.upper():
+                return f"{description} {deprecated_message}"
+            return description
+
+        if deprecated_message:
+            return deprecated_message
+
+        return description
+
     def parse_type_alias(self, node: ast.Assign, next_node: Optional[ast.Expr] = None) -> Optional[ParsedTypeAlias]:
         """Parse a type alias assignment (e.g., Category = Literal[...])."""
         # Only handle simple name assignments
@@ -383,8 +424,10 @@ class DocGenerator:
                 # Try to extract from Pydantic Field() first
                 field_type, pydantic_desc = self.extract_pydantic_field_info(item.annotation)
 
+                field_call_desc = self.extract_field_call_description(item.value)
+
                 # Use Pydantic description, fall back to docstring attributes
-                field_desc = pydantic_desc or attr_descriptions.get(field_name)
+                field_desc = pydantic_desc or field_call_desc or attr_descriptions.get(field_name)
                 fields.append((field_name, field_type, field_desc))
 
         return ParsedClass(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.12.1",
+    version="2.12.2",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/integration/test_find_similar_integration.py
+++ b/tests/integration/test_find_similar_integration.py
@@ -1,16 +1,20 @@
-"""Integration tests for find_similar() method with contents options."""
+"""Compatibility tests for deprecated find_similar() contents behavior.
+
+New code should use search() instead.
+"""
 
 import pytest
 
 
 class TestFindSimilarContentsOptions:
-    """Test suite for find_similar() contents behavior."""
+    """Compatibility suite for deprecated find_similar() contents behavior."""
 
     TEST_URL = "https://en.wikipedia.org/wiki/Ant"
 
     def test_defaults_to_text_contents_with_10k_max_characters(self, exa):
-        """Verify find_similar() returns text contents with 10,000 max chars by default."""
-        response = exa.find_similar(self.TEST_URL, num_results=2)
+        """Verify deprecated find_similar() returns default text contents."""
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            response = exa.find_similar(self.TEST_URL, num_results=2)
 
         assert len(response.results) > 0
         sample_result = response.results[0]
@@ -19,8 +23,9 @@ class TestFindSimilarContentsOptions:
         assert len(sample_result.text) <= 10_000
 
     def test_returns_no_contents_when_explicitly_false(self, exa):
-        """Verify find_similar() returns no contents when contents=False."""
-        response = exa.find_similar(self.TEST_URL, contents=False, num_results=2)
+        """Verify deprecated find_similar() returns no contents when contents=False."""
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            response = exa.find_similar(self.TEST_URL, contents=False, num_results=2)
 
         assert len(response.results) > 0
         sample_result = response.results[0]
@@ -28,10 +33,11 @@ class TestFindSimilarContentsOptions:
         assert sample_result.summary is None
 
     def test_returns_text_contents_when_explicitly_requested(self, exa):
-        """Verify find_similar() returns text when explicitly requested."""
-        response = exa.find_similar(
-            self.TEST_URL, contents={"text": True}, num_results=2
-        )
+        """Verify deprecated find_similar() returns text when explicitly requested."""
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            response = exa.find_similar(
+                self.TEST_URL, contents={"text": True}, num_results=2
+            )
 
         assert len(response.results) > 0
         sample_result = response.results[0]
@@ -39,13 +45,14 @@ class TestFindSimilarContentsOptions:
         assert len(sample_result.text) > 100
 
     def test_returns_text_with_custom_max_characters(self, exa):
-        """Verify find_similar() respects custom maxCharacters."""
+        """Verify deprecated find_similar() respects custom maxCharacters."""
         max_chars = 500
-        response = exa.find_similar(
-            self.TEST_URL,
-            contents={"text": {"max_characters": max_chars}},
-            num_results=2,
-        )
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            response = exa.find_similar(
+                self.TEST_URL,
+                contents={"text": {"max_characters": max_chars}},
+                num_results=2,
+            )
 
         assert len(response.results) > 0
         sample_result = response.results[0]
@@ -54,10 +61,11 @@ class TestFindSimilarContentsOptions:
 
     @pytest.mark.timeout(15)
     def test_returns_summary_when_requested(self, exa):
-        """Verify find_similar() returns summary when requested."""
-        response = exa.find_similar(
-            self.TEST_URL, contents={"summary": True}, num_results=2
-        )
+        """Verify deprecated find_similar() returns summary when requested."""
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            response = exa.find_similar(
+                self.TEST_URL, contents={"summary": True}, num_results=2
+            )
 
         assert len(response.results) > 0
         sample_result = response.results[0]
@@ -67,12 +75,13 @@ class TestFindSimilarContentsOptions:
 
     @pytest.mark.timeout(20)
     def test_returns_both_text_and_summary(self, exa):
-        """Verify find_similar() can return both text and summary."""
-        response = exa.find_similar(
-            self.TEST_URL,
-            contents={"text": {"max_characters": 1000}, "summary": True},
-            num_results=2,
-        )
+        """Verify deprecated find_similar() can return both text and summary."""
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            response = exa.find_similar(
+                self.TEST_URL,
+                contents={"text": {"max_characters": 1000}, "summary": True},
+                num_results=2,
+            )
 
         assert len(response.results) > 0
         sample_result = response.results[0]
@@ -83,10 +92,11 @@ class TestFindSimilarContentsOptions:
         assert len(sample_result.summary) > 10
 
     def test_defaults_to_text_when_passing_other_options(self, exa):
-        """Verify find_similar() defaults to text even with other options."""
-        response = exa.find_similar(
-            self.TEST_URL, num_results=3, exclude_source_domain=True
-        )
+        """Verify deprecated find_similar() defaults to text with other options."""
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            response = exa.find_similar(
+                self.TEST_URL, num_results=3, exclude_source_domain=True
+            )
 
         assert len(response.results) == 3
         sample_result = response.results[0]
@@ -96,13 +106,14 @@ class TestFindSimilarContentsOptions:
 
 @pytest.mark.asyncio
 class TestAsyncFindSimilarContentsOptions:
-    """Test suite for async find_similar() contents behavior."""
+    """Compatibility suite for deprecated async find_similar() contents behavior."""
 
     TEST_URL = "https://en.wikipedia.org/wiki/Ant"
 
     async def test_async_defaults_to_text_contents(self, async_exa):
-        """Verify async find_similar() returns text contents by default."""
-        response = await async_exa.find_similar(self.TEST_URL, num_results=2)
+        """Verify deprecated async find_similar() returns text contents by default."""
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            response = await async_exa.find_similar(self.TEST_URL, num_results=2)
 
         assert len(response.results) > 0
         sample_result = response.results[0]
@@ -111,10 +122,11 @@ class TestAsyncFindSimilarContentsOptions:
         assert len(sample_result.text) <= 10_000
 
     async def test_async_returns_no_contents_when_false(self, async_exa):
-        """Verify async find_similar() returns no contents when contents=False."""
-        response = await async_exa.find_similar(
-            self.TEST_URL, contents=False, num_results=2
-        )
+        """Verify deprecated async find_similar() returns no contents when contents=False."""
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            response = await async_exa.find_similar(
+                self.TEST_URL, contents=False, num_results=2
+            )
 
         assert len(response.results) > 0
         sample_result = response.results[0]

--- a/tests/unit/test_pydantic_schemas.py
+++ b/tests/unit/test_pydantic_schemas.py
@@ -9,7 +9,11 @@ import pytest
 from typing import List, Optional
 from pydantic import BaseModel, Field
 
-from exa_py.api import _convert_schema_input, JSONSchemaInput, JSONSchema
+from exa_py.api import (
+    JSONSchema,  # DEPRECATED TYPE: kept here only for backward compatibility tests.
+    JSONSchemaInput,
+    _convert_schema_input,
+)
 
 
 class SimpleModel(BaseModel):
@@ -118,7 +122,7 @@ class TestSchemaConversion:
         assert result is schema_dict  # Should be the same object
 
     def test_legacy_jsonschema_support(self):
-        """Test that legacy JSONSchema TypedDict instances work."""
+        """Deprecated JSONSchema TypedDict instances still work for compatibility."""
         legacy_schema: JSONSchema = {
             "type": "object",
             "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
@@ -164,8 +168,8 @@ class TestTypeAnnotations:
         assert isinstance(result2, dict)
 
     def test_backward_compatibility_with_typeddict(self):
-        """Test that old JSONSchema TypedDict usage still works."""
-        # This simulates the old usage pattern
+        """Deprecated JSONSchema TypedDict usage still works for compatibility."""
+        # DEPRECATED TYPE: simulate the old JSONSchema usage pattern.
         old_style_schema: JSONSchema = {
             "type": "object",
             "properties": {

--- a/tests/unit/test_search_api.py
+++ b/tests/unit/test_search_api.py
@@ -75,16 +75,16 @@ def test_search_accepts_user_location_offline():
 
 def test_search_accepts_additional_queries_offline():
     """Test that search method accepts additional_queries parameter for deep search.
-    
-    Deep search always returns context in the response.
+
+    Deep search may return the deprecated context response field for backward compatibility.
     """
     exa = Exa(API_KEY)
-    # Create a mock response with context (always returned for deep search)
+    # Mock the deprecated context response field that may be returned for deep search.
     mock_response = {
         "results": [
             {"url": "http://example.com", "id": "1", "title": "Deep Search Result"}
         ],
-        "context": "Deep search context string",
+        "context": "Deep search context string",  # DEPRECATED FIELD: legacy response key.
         "costDollars": {"total": 0.002},
     }
 
@@ -97,8 +97,8 @@ def test_search_accepts_additional_queries_offline():
             num_results=5,
         )
         assert isinstance(resp, exa_api.SearchResponse)
-        assert resp.context is not None  # Context always present for deep search
-        
+        assert resp.context is not None  # DEPRECATED FIELD: legacy context response.
+
         # Verify the request was called with correct camelCase parameters
         call_args = mock_request.call_args
         assert call_args[0][0] == "/search"
@@ -629,8 +629,8 @@ def test_search_accepts_highlights_option_offline():
         assert options["contents"]["highlights"] is True
 
 
-def test_search_accepts_highlights_with_options_offline():
-    """Test that search method accepts detailed highlights options."""
+def test_search_accepts_deprecated_highlights_options_offline():
+    """Deprecated num_sentences/highlights_per_url are kept for compatibility."""
     exa = Exa(API_KEY)
     mock_response = {
         "results": [
@@ -651,8 +651,8 @@ def test_search_accepts_highlights_with_options_offline():
             contents={
                 "highlights": {
                     "query": "key points",
-                    "num_sentences": 2,
-                    "highlights_per_url": 3,
+                    "num_sentences": 2,  # DEPRECATED FIELD: use max_characters.
+                    "highlights_per_url": 3,  # DEPRECATED FIELD: use max_characters.
                 }
             },
             num_results=1,
@@ -660,13 +660,13 @@ def test_search_accepts_highlights_with_options_offline():
         assert isinstance(resp, exa_api.SearchResponse)
         assert resp.results[0].highlights == ["highlight 1"]
 
-        # Verify the request was called with correct camelCase parameters
+        # Verify deprecated fields still map to their legacy camelCase parameters.
         call_args = mock_request.call_args
         options = call_args[0][1]
         highlights_opts = options["contents"]["highlights"]
         assert highlights_opts["query"] == "key points"
-        assert highlights_opts["numSentences"] == 2
-        assert highlights_opts["highlightsPerUrl"] == 3
+        assert highlights_opts["numSentences"] == 2  # DEPRECATED FIELD: legacy API key.
+        assert highlights_opts["highlightsPerUrl"] == 3  # DEPRECATED FIELD: legacy API key.
 
 
 def test_search_accepts_highlights_with_max_characters_offline():
@@ -900,19 +900,22 @@ async def test_get_contents_async_live():
 
 
 ########################################
-# Live tests for new context / statuses features
+# Live tests for deprecated context compatibility / statuses features
 ########################################
 
 
 @pytest.mark.skipif(not _have_real_key(), reason="EXA_API_KEY not provided")
 def test_search_and_contents_context_live():
-    """search_and_contents with context=True should return non-empty context string."""
+    """Deprecated context=True compatibility should return a context string."""
     exa = Exa(API_KEY)
     resp = exa.search_and_contents(
-        "openai research", num_results=3, context=True, text=False
+        "openai research",
+        num_results=3,
+        context=True,  # DEPRECATED FIELD: use highlights or text.
+        text=False,
     )
     assert (
-        resp.context is not None
+        resp.context is not None  # DEPRECATED FIELD: legacy context response.
         and isinstance(resp.context, str)
         and len(resp.context) > 0
     )
@@ -920,12 +923,15 @@ def test_search_and_contents_context_live():
 
 @pytest.mark.skipif(not _have_real_key(), reason="EXA_API_KEY not provided")
 def test_find_similar_and_contents_context_live():
-    """find_similar_and_contents with context flag should include context string."""
+    """Deprecated context=True compatibility should include the context field."""
     exa = Exa(API_KEY)
     resp = exa.find_similar_and_contents(
-        "https://example.com", num_results=3, context=True, text=False
+        "https://example.com",
+        num_results=3,
+        context=True,  # DEPRECATED FIELD: use highlights or text.
+        text=False,
     )
-    # context may be empty depending on backend, but attribute should exist (None or str)
+    # DEPRECATED FIELD: context may be empty, but legacy attribute should exist.
     assert hasattr(resp, "context")
 
 
@@ -963,14 +969,14 @@ def test_search_with_highlights_live():
 
 @pytest.mark.skipif(not _have_real_key(), reason="EXA_API_KEY not provided")
 def test_search_with_highlights_options_live():
-    """search with detailed highlights options should work."""
+    """Deprecated highlight count fields should still work for compatibility."""
     exa = Exa(API_KEY)
     resp = exa.search(
         "machine learning",
         contents={
             "highlights": {
-                "num_sentences": 2,
-                "highlights_per_url": 3,
+                "num_sentences": 2,  # DEPRECATED FIELD: use max_characters.
+                "highlights_per_url": 3,  # DEPRECATED FIELD: use max_characters.
             }
         },
         num_results=2,

--- a/tests/unit/test_search_api.py
+++ b/tests/unit/test_search_api.py
@@ -73,6 +73,22 @@ def test_search_accepts_user_location_offline():
         assert isinstance(resp, exa_api.SearchResponse)
 
 
+def test_find_similar_deprecated_offline():
+    """Verify deprecated find_similar() still works for compatibility and warns."""
+    exa = Exa(API_KEY)
+    mock_response = {
+        "results": [{"url": "http://example.com", "id": "1", "title": "Test"}],
+        "costDollars": {"total": 0.001},
+    }
+
+    with patch.object(exa, "request", return_value=mock_response) as mock_request:
+        with pytest.warns(DeprecationWarning, match="find_similar"):
+            resp = exa.find_similar("https://example.com", num_results=1)
+
+        assert isinstance(resp, exa_api.SearchResponse)
+        assert mock_request.call_args[0][0] == "/findSimilar"
+
+
 def test_search_accepts_additional_queries_offline():
     """Test that search method accepts additional_queries parameter for deep search.
 
@@ -878,7 +894,8 @@ def test_search_with_user_location_live():
 @pytest.mark.skipif(not _have_real_key(), reason="EXA_API_KEY not provided")
 def test_find_similar_live():
     exa = Exa(API_KEY)
-    resp = exa.find_similar("https://example.com", num_results=1)
+    with pytest.warns(DeprecationWarning, match="find_similar"):
+        resp = exa.find_similar("https://example.com", num_results=1)
     assert resp.results
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.12.1"
+version = "2.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary

Makes deprecated SDK surfaces obvious to humans, IDE/type-checking tools, schema consumers, generated docs, and LLMs while preserving backward compatibility.

## What Changed

- Added PEP 702 `@deprecated` markers to legacy `JSONSchema`, `search_and_contents()`, `find_similar()/findSimilar`, and `find_similar_and_contents()` for sync/async clients, including overloads where applicable.
- Reworded public docstrings and generated SDK docs so `search()` is the clear replacement for `findSimilar`, `search_and_contents()`, and `find_similar_and_contents()`.
- Labeled deprecated content fields directly at their public definitions: `contents.context`, `SearchResponse.context`, `ContextContentsOptions`, `num_sentences`, and `highlights_per_url`.
- Uses native Pydantic `Field(deprecated=...)` metadata for deprecated Search Monitor schema fields, and updates the docs generator to extract those descriptions/deprecation messages from `Field(...)` calls.
- Regenerated `docs/python-sdk-specification.mdx`, made compatibility tests explicitly describe deprecated usage, and bumped package metadata plus `uv.lock` to `2.12.2`.

## Compatibility

Deprecated paths still call the existing endpoints and remain covered by compatibility tests; this PR changes discoverability and warnings, not wire behavior.

## Validation

- `python3 -m compileall -q exa_py scripts tests`
- `diff -u docs/python-sdk-specification.mdx <(python3 scripts/generate_docs.py)`
- `git diff --check`
- `.venv/bin/python -m pytest tests/unit` on Python 3.13.13: `175 passed, 14 skipped, 2 warnings`
- `.venv/bin/python -m pytest tests/integration/test_find_similar_integration.py`: `9 skipped` without `EXA_API_KEY`; also reports the file's existing unknown `timeout` mark warnings