### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with get_running_loop() in poll_until_finished

### DIFF
--- a/exa_py/research/async_client.py
+++ b/exa_py/research/async_client.py
@@ -277,7 +277,7 @@ class AsyncResearchClient(AsyncResearchBaseClient):
         poll_interval_sec = poll_interval / 1000
         timeout_sec = timeout_ms / 1000
         max_consecutive_failures = 5
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         consecutive_failures = 0
 
         while True:
@@ -304,7 +304,7 @@ class AsyncResearchClient(AsyncResearchBaseClient):
                         f"for research {research_id}: {e}"
                     )
 
-            if asyncio.get_event_loop().time() - start_time > timeout_sec:
+            if asyncio.get_running_loop().time() - start_time > timeout_sec:
                 raise TimeoutError(
                     f"Research {research_id} did not complete within {timeout_ms}ms"
                 )


### PR DESCRIPTION
## What this PR fixes

In `exa_py/research/async_client.py`, `poll_until_finished` uses `asyncio.get_event_loop().time()` to track elapsed time.

`asyncio.get_event_loop()` is deprecated since Python 3.10 when called inside a coroutine. Using it inside an `async` function emits a DeprecationWarning and may raise a RuntimeError in future Python versions.

The correct replacement when already inside a running async context is `asyncio.get_running_loop()`.

## Changes

- `async_client.py`: replaced 2 occurrences of `asyncio.get_event_loop().time()` with `asyncio.get_running_loop().time()` inside the `poll_until_finished` coroutine

## References

- Python docs: https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_running_loop
- Python 3.10 deprecation notice for `get_event_loop()` in running loops