### PR TITLE
fix: accept structured monitor run output content

### DIFF
--- a/exa_py/monitors/types.py
+++ b/exa_py/monitors/types.py
@@ -192,7 +192,7 @@ class GroundingEntry(BaseModel):
 
 class SearchMonitorRunOutput(BaseModel):
     results: Optional[List[Dict[str, Any]]] = None
-    content: Optional[str] = None
+    content: Optional[Union[str, Dict[str, Any], List[Dict[str, Any]]]] = None
     grounding: Optional[List[GroundingEntry]] = None
 
     model_config = {"populate_by_name": True}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.13.0"
+version = "2.13.1"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.13.0"
+version = "2.13.1"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.13.0",
+    version="2.13.1",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/unit/test_search_monitors.py
+++ b/tests/unit/test_search_monitors.py
@@ -172,6 +172,56 @@ class TestSearchMonitorRunsListAll:
         assert len(results) == 2
         assert results[0].id == "run_1"
 
+    def test_list_accepts_structured_object_output_content(self, monitors_client, mock_client):
+        mock_client.request.return_value = {
+            "data": [
+                {
+                    **_make_run("run_1"),
+                    "output": {
+                        "content": {
+                            "hits": [{"id": "anthropic", "score": 0.99}],
+                            "when": "May 2026",
+                        }
+                    },
+                }
+            ],
+            "hasMore": False,
+            "nextCursor": None,
+        }
+
+        response = monitors_client.runs.list("sm_123")
+
+        assert response.data[0].output is not None
+        assert response.data[0].output.content == {
+            "hits": [{"id": "anthropic", "score": 0.99}],
+            "when": "May 2026",
+        }
+
+    def test_list_accepts_structured_list_output_content(self, monitors_client, mock_client):
+        mock_client.request.return_value = {
+            "data": [
+                {
+                    **_make_run("run_1"),
+                    "output": {
+                        "content": [
+                            {"title": "First hit", "url": "https://example.com/1"},
+                            {"title": "Second hit", "url": "https://example.com/2"},
+                        ]
+                    },
+                }
+            ],
+            "hasMore": False,
+            "nextCursor": None,
+        }
+
+        response = monitors_client.runs.list("sm_123")
+
+        assert response.data[0].output is not None
+        assert response.data[0].output.content == [
+            {"title": "First hit", "url": "https://example.com/1"},
+            {"title": "Second hit", "url": "https://example.com/2"},
+        ]
+
     def test_list_all_multiple_pages(self, monitors_client, mock_client):
         mock_client.request.side_effect = [
             {"data": [_make_run("run_1")], "hasMore": True, "nextCursor": "cursor_1"},

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.13.0"
+version = "2.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary
- allow `SearchMonitorRunOutput.content` to deserialize structured object payloads
- allow monitor run output content to deserialize lists of structured objects
- add regression tests covering both structured monitor output shapes

## Testing
- uv run pytest tests/unit/test_search_monitors.py -q
- uv run pytest tests/unit -q

Fixes #208
