### PR TITLE
fix(monitors): accept structured object in SearchMonitorRunOutput.content

### DIFF
--- a/docs/python-sdk-specification.mdx
+++ b/docs/python-sdk-specification.mdx
@@ -1842,7 +1842,7 @@ deprecated and kept only for backward compatibility.
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | results | Optional[List[Dict[str, Any]]] | - |
-| content | Optional[str] | - |
+| content | Optional[Union[str, Dict[str, Any]]] | - |
 | grounding | Optional[List[[GroundingEntry](#groundingentry)]] | - |
 
 #### `SearchMonitor`

--- a/exa_py/monitors/types.py
+++ b/exa_py/monitors/types.py
@@ -192,7 +192,7 @@ class GroundingEntry(BaseModel):
 
 class SearchMonitorRunOutput(BaseModel):
     results: Optional[List[Dict[str, Any]]] = None
-    content: Optional[str] = None
+    content: Optional[Union[str, Dict[str, Any]]] = None
     grounding: Optional[List[GroundingEntry]] = None
 
     model_config = {"populate_by_name": True}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.13.0"
+version = "2.13.1"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.13.0"
+version = "2.13.1"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.13.0",
+    version="2.13.1",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/unit/test_search_monitors.py
+++ b/tests/unit/test_search_monitors.py
@@ -200,4 +200,36 @@ class TestTriggerResponse:
         mock_client.request.return_value = {"triggered": True}
         result = monitors_client.trigger("sm_123")
         assert isinstance(result, TriggerSearchMonitorResponse)
-        assert result.triggered is True
+
+
+class TestSearchMonitorRunOutputContent:
+    """Runs configured with an outputSchema return ``output.content`` as a
+    structured object, so the field must accept both ``str`` and ``dict``."""
+
+    def _make_run_with_content(self, content) -> dict:
+        run = _make_run("run_1")
+        run["output"] = {"results": None, "content": content, "grounding": None}
+        return run
+
+    def test_get_run_with_structured_content(self, monitors_client, mock_client):
+        structured = {"summary": "AI breakthroughs", "count": 3}
+        mock_client.request.return_value = self._make_run_with_content(structured)
+        run = monitors_client.runs.get("sm_123", "run_1")
+        assert run.output is not None
+        assert run.output.content == structured
+
+    def test_get_run_with_string_content(self, monitors_client, mock_client):
+        mock_client.request.return_value = self._make_run_with_content("plain text")
+        run = monitors_client.runs.get("sm_123", "run_1")
+        assert run.output is not None
+        assert run.output.content == "plain text"
+
+    def test_list_runs_with_structured_content(self, monitors_client, mock_client):
+        structured = {"summary": "AI breakthroughs"}
+        mock_client.request.return_value = {
+            "data": [self._make_run_with_content(structured)],
+            "hasMore": False,
+            "nextCursor": None,
+        }
+        runs = monitors_client.runs.list("sm_123")
+        assert runs.data[0].output.content == structured

--- a/tests/unit/test_search_monitors.py
+++ b/tests/unit/test_search_monitors.py
@@ -200,6 +200,7 @@ class TestTriggerResponse:
         mock_client.request.return_value = {"triggered": True}
         result = monitors_client.trigger("sm_123")
         assert isinstance(result, TriggerSearchMonitorResponse)
+        assert result.triggered is True
 
 
 class TestSearchMonitorRunOutputContent:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 
 [[package]]
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.13.0"
+version = "2.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary
A search monitor configured with an `outputSchema` returns `output.content` as a structured JSON **object**, but the SDK typed it as `Optional[str]`. Retrieving such a run (`monitors.runs.get` / `monitors.runs.list`) therefore raised a pydantic `ValidationError` — the SDK rejecting the API's own response.

Fix is a one-line type widening that mirrors the already-correct `DeepSearchOutput.content`:

```diff
 class SearchMonitorRunOutput(BaseModel):
     results: Optional[List[Dict[str, Any]]] = None
-    content: Optional[str] = None
+    content: Optional[Union[str, Dict[str, Any]]] = None
     grounding: Optional[List[GroundingEntry]] = None
```

### Reproduction (before)
Triggering a monitor with an `outputSchema` and listing its runs crashed:
```
ValidationError: 1 validation error for ListSearchMonitorRunsResponse
data.0.output.content
  Input should be a valid string [type=string_type, input_value={'summary': ...}, input_type=dict]
```
After the fix, the same call validates and `run.output.content` is the dict the API returned. Verified end-to-end against the live API (create monitor → trigger → list/get run).

## Changes
- `exa_py/monitors/types.py`: widen `SearchMonitorRunOutput.content` to `Optional[Union[str, Dict[str, Any]]]`.
- `tests/unit/test_search_monitors.py`: add regression tests for structured (dict) and string `content` via `runs.get` and `runs.list`.
- Version bump `2.13.0` → `2.13.1` (`pyproject.toml` ×2, `setup.py`), `uv lock` synced, and regenerated `docs/python-sdk-specification.mdx`.

Link to Devin session: https://app.devin.ai/sessions/766bce30752c42d3a86863884adc7631
Requested by: @maxwbuckley
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-py/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->