### PR TITLE
Allow decimal Agent ACUs

### DIFF
--- a/exa_py/agent/types.py
+++ b/exa_py/agent/types.py
@@ -47,7 +47,7 @@ class AgentOutput(BaseModel):
 
 
 class AgentUsage(BaseModel):
-    agent_compute_units: Optional[int] = Field(default=None, alias="agentComputeUnits")
+    agent_compute_units: Optional[float] = Field(default=None, alias="agentComputeUnits")
     searches: Optional[int] = None
     emails: Optional[int] = None
     phone_numbers: Optional[int] = Field(default=None, alias="phoneNumbers")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.13.1"
+version = "2.13.2"
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.13.1"
+version = "2.13.2"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.13.1",
+    version="2.13.2",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -46,7 +46,7 @@ def _make_run(run_id: str = "agent_run_123") -> dict:
                 }
             ],
         },
-        "usage": {"agentComputeUnits": 100, "searches": 2},
+        "usage": {"agentComputeUnits": 0.1, "searches": 2},
         "costDollars": {"total": 0.02, "agentCompute": 0.01, "search": 0.01},
     }
 
@@ -97,6 +97,7 @@ def test_create_agent_run(run_client, mock_client):
 
     assert result.id == "agent_run_123"
     assert result.output.structured == {"companies": [{"name": "Example AI"}]}
+    assert result.usage.agent_compute_units == 0.1
     mock_client.request.assert_called_once_with(
         "/agent/runs",
         data={

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 
 [[package]]
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.13.1"
+version = "2.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary

Update the Python SDK Agent usage model so `agent_compute_units` accepts decimal values returned by the Agent API.

## Details

The Agent API now reports ACUs as fractional values instead of whole integers. This changes the Pydantic model for Agent usage from `Optional[int]` to `Optional[float]`, updates the Agent unit-test fixture to use a decimal ACU value, and asserts that the parsed model preserves the decimal value.

This also bumps the SDK version from `2.13.1` to `2.13.2` in the required version locations and syncs `uv.lock`.

## OpenAPI

No change is needed in the separate `openapi-spec` repo: `origin/master` there does not include the Agent API or `agentComputeUnits`. The public Agent OpenAPI schema is owned by Nova in the monorepo and has already been updated to `type: number`.

## Validation

- `uv run pytest tests/unit/test_agent.py`
- `uv lock`
- `uv run python scripts/generate_docs.py > docs/python-sdk-specification.mdx`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-py/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->