### PR TITLE
[codex] add responses client

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -45,6 +45,7 @@ from .websets.core.base import ExaJSONEncoder
 from .monitors import SearchMonitorsClient, AsyncSearchMonitorsClient
 from .research import ResearchClient, AsyncResearchClient
 from .agent import BetaClient, AsyncBetaClient
+from .responses import ResponsesClient, AsyncResponsesClient
 
 
 is_beta = os.getenv("IS_BETA") == "True"
@@ -1459,6 +1460,8 @@ class Exa:
         self.research = ResearchClient(self)
         # Search Monitors client
         self.monitors = SearchMonitorsClient(self)
+        # OpenAI-compatible Responses client for Agent.
+        self.responses = ResponsesClient(self)
         # Beta clients
         self.beta = BetaClient(self)
 
@@ -2661,6 +2664,8 @@ class AsyncExa(Exa):
         self.websets = AsyncWebsetsClient(self)
         # Override the synchronous SearchMonitorsClient with its async counterpart.
         self.monitors = AsyncSearchMonitorsClient(self)
+        # Override the synchronous Responses client with its async counterpart.
+        self.responses = AsyncResponsesClient(self)
         # Override the synchronous beta clients with async counterparts.
         self.beta = AsyncBetaClient(self)
         self._client = None

--- a/exa_py/responses/__init__.py
+++ b/exa_py/responses/__init__.py
@@ -1,0 +1,37 @@
+"""Exa OpenAI-compatible Responses API client."""
+
+from .client import AsyncResponsesClient, ResponsesClient
+from .types import (
+    AgentResponseEffort,
+    AgentResponseModel,
+    Response,
+    ResponseError,
+    ResponseIncompleteDetails,
+    ResponseInputMessageParam,
+    ResponseInputParam,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponseReasoningParam,
+    ResponseStatus,
+    ResponseTextConfigParam,
+    ResponseTextFormatParam,
+)
+
+__all__ = [
+    "AgentResponseEffort",
+    "AgentResponseModel",
+    "AsyncResponsesClient",
+    "Response",
+    "ResponseError",
+    "ResponseIncompleteDetails",
+    "ResponseInputMessageParam",
+    "ResponseInputParam",
+    "ResponseOutputMessage",
+    "ResponseOutputText",
+    "ResponseReasoningParam",
+    "ResponseStatus",
+    "ResponseTextConfigParam",
+    "ResponseTextFormatParam",
+    "ResponsesClient",
+]
+

--- a/exa_py/responses/client.py
+++ b/exa_py/responses/client.py
@@ -115,7 +115,7 @@ class ResponsesClient:
             **kwargs,
         }
         response = self._client.request(
-            "/v1/responses",
+            "/responses",
             data={key: value for key, value in payload.items() if value is not None},
             method="POST",
         )
@@ -202,7 +202,7 @@ class AsyncResponsesClient:
             **kwargs,
         }
         response = await self._client.async_request(
-            "/v1/responses",
+            "/responses",
             data={key: value for key, value in payload.items() if value is not None},
             method="POST",
         )

--- a/exa_py/responses/client.py
+++ b/exa_py/responses/client.py
@@ -66,7 +66,8 @@ class ResponsesClient:
             input: The user input string or Responses message list.
             model: The Responses model name. Defaults to ``"agent"``.
             reasoning: Optional reasoning configuration. ``reasoning["effort"]``
-                maps to Agent effort modes: ``low``, ``medium``, ``high``, ``xhigh``, or ``auto``.
+                maps to Agent effort modes: ``minimal``, ``low``, ``medium``, ``high``,
+                ``xhigh``, or ``auto``.
             instructions: Optional system or developer instructions.
             previous_response_id: Optional previous response ID for follow-up context.
             metadata: Optional metadata to attach to the response.
@@ -90,7 +91,7 @@ class ResponsesClient:
             response = exa.responses.create(
                 model="agent",
                 input="Find companies building browser automation tools.",
-                reasoning={"effort": "low"},
+                reasoning={"effort": "minimal"},
             )
             print(response.output_text)
         """
@@ -152,7 +153,8 @@ class AsyncResponsesClient:
             input: The user input string or Responses message list.
             model: The Responses model name. Defaults to ``"agent"``.
             reasoning: Optional reasoning configuration. ``reasoning["effort"]``
-                maps to Agent effort modes: ``low``, ``medium``, ``high``, ``xhigh``, or ``auto``.
+                maps to Agent effort modes: ``minimal``, ``low``, ``medium``, ``high``,
+                ``xhigh``, or ``auto``.
             instructions: Optional system or developer instructions.
             previous_response_id: Optional previous response ID for follow-up context.
             metadata: Optional metadata to attach to the response.
@@ -176,7 +178,7 @@ class AsyncResponsesClient:
             response = await exa.responses.create(
                 model="agent",
                 input="Find companies building browser automation tools.",
-                reasoning={"effort": "low"},
+                reasoning={"effort": "minimal"},
             )
             print(response.output_text)
         """
@@ -205,4 +207,3 @@ class AsyncResponsesClient:
             method="POST",
         )
         return Response.model_validate(response)
-

--- a/exa_py/responses/client.py
+++ b/exa_py/responses/client.py
@@ -1,0 +1,208 @@
+"""Synchronous and asynchronous clients for Exa's Responses API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Literal, Optional, Union, overload
+
+from .types import (
+    AgentResponseEffort,
+    AgentResponseModel,
+    Response,
+    ResponseInputParam,
+    ResponseReasoningParam,
+    ResponseTextConfigParam,
+)
+
+
+class ResponsesClient:
+    """Synchronous client for OpenAI-compatible Agent responses."""
+
+    def __init__(self, client: Any):
+        self._client = client
+
+    @overload
+    def create(
+        self,
+        *,
+        input: ResponseInputParam,
+        model: Union[AgentResponseModel, str] = "agent",
+        reasoning: Optional[ResponseReasoningParam] = None,
+        instructions: Optional[str] = None,
+        previous_response_id: Optional[str] = None,
+        metadata: Optional[Dict[str, str]] = None,
+        text: Optional[ResponseTextConfigParam] = None,
+        stream: Literal[False] = False,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        tools: Optional[Iterable[Dict[str, Any]]] = None,
+        tool_choice: Optional[Any] = None,
+        max_output_tokens: Optional[int] = None,
+        store: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> Response: ...
+
+    def create(
+        self,
+        *,
+        input: ResponseInputParam,
+        model: Union[AgentResponseModel, str] = "agent",
+        reasoning: Optional[ResponseReasoningParam] = None,
+        instructions: Optional[str] = None,
+        previous_response_id: Optional[str] = None,
+        metadata: Optional[Dict[str, str]] = None,
+        text: Optional[ResponseTextConfigParam] = None,
+        stream: bool = False,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        tools: Optional[Iterable[Dict[str, Any]]] = None,
+        tool_choice: Optional[Any] = None,
+        max_output_tokens: Optional[int] = None,
+        store: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> Response:
+        """Create a non-streaming Agent response.
+
+        Args:
+            input: The user input string or Responses message list.
+            model: The Responses model name. Defaults to ``"agent"``.
+            reasoning: Optional reasoning configuration. ``reasoning["effort"]``
+                maps to Agent effort modes: ``low``, ``medium``, ``high``, ``xhigh``, or ``auto``.
+            instructions: Optional system or developer instructions.
+            previous_response_id: Optional previous response ID for follow-up context.
+            metadata: Optional metadata to attach to the response.
+            text: Optional text output configuration, including JSON schema format.
+            stream: Must be ``False``. Streaming Responses are not supported yet.
+            temperature: Accepted for OpenAI compatibility and ignored by the API.
+            top_p: Accepted for OpenAI compatibility and ignored by the API.
+            tools: Accepted for OpenAI compatibility and ignored by the API.
+            tool_choice: Accepted for OpenAI compatibility and ignored by the API.
+            max_output_tokens: Accepted for OpenAI compatibility and ignored by the API.
+            store: Optional OpenAI-compatible store flag.
+            **kwargs: Additional OpenAI-compatible fields forwarded to the API.
+
+        Returns:
+            A Responses-compatible object with ``output_text``.
+
+        Examples:
+            from exa_py import Exa
+
+            exa = Exa("EXA_API_KEY")
+            response = exa.responses.create(
+                model="agent",
+                input="Find companies building browser automation tools.",
+                reasoning={"effort": "low"},
+            )
+            print(response.output_text)
+        """
+        if stream:
+            raise ValueError("Streaming Responses are not supported yet.")
+
+        payload = {
+            "input": input,
+            "model": model,
+            "reasoning": reasoning,
+            "instructions": instructions,
+            "previous_response_id": previous_response_id,
+            "metadata": metadata,
+            "text": text,
+            "temperature": temperature,
+            "top_p": top_p,
+            "tools": list(tools) if tools is not None else None,
+            "tool_choice": tool_choice,
+            "max_output_tokens": max_output_tokens,
+            "store": store,
+            **kwargs,
+        }
+        response = self._client.request(
+            "/v1/responses",
+            data={key: value for key, value in payload.items() if value is not None},
+            method="POST",
+        )
+        return Response.model_validate(response)
+
+
+class AsyncResponsesClient:
+    """Asynchronous client for OpenAI-compatible Agent responses."""
+
+    def __init__(self, client: Any):
+        self._client = client
+
+    async def create(
+        self,
+        *,
+        input: ResponseInputParam,
+        model: Union[AgentResponseModel, str] = "agent",
+        reasoning: Optional[ResponseReasoningParam] = None,
+        instructions: Optional[str] = None,
+        previous_response_id: Optional[str] = None,
+        metadata: Optional[Dict[str, str]] = None,
+        text: Optional[ResponseTextConfigParam] = None,
+        stream: bool = False,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        tools: Optional[Iterable[Dict[str, Any]]] = None,
+        tool_choice: Optional[Any] = None,
+        max_output_tokens: Optional[int] = None,
+        store: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> Response:
+        """Create a non-streaming Agent response asynchronously.
+
+        Args:
+            input: The user input string or Responses message list.
+            model: The Responses model name. Defaults to ``"agent"``.
+            reasoning: Optional reasoning configuration. ``reasoning["effort"]``
+                maps to Agent effort modes: ``low``, ``medium``, ``high``, ``xhigh``, or ``auto``.
+            instructions: Optional system or developer instructions.
+            previous_response_id: Optional previous response ID for follow-up context.
+            metadata: Optional metadata to attach to the response.
+            text: Optional text output configuration, including JSON schema format.
+            stream: Must be ``False``. Streaming Responses are not supported yet.
+            temperature: Accepted for OpenAI compatibility and ignored by the API.
+            top_p: Accepted for OpenAI compatibility and ignored by the API.
+            tools: Accepted for OpenAI compatibility and ignored by the API.
+            tool_choice: Accepted for OpenAI compatibility and ignored by the API.
+            max_output_tokens: Accepted for OpenAI compatibility and ignored by the API.
+            store: Optional OpenAI-compatible store flag.
+            **kwargs: Additional OpenAI-compatible fields forwarded to the API.
+
+        Returns:
+            A Responses-compatible object with ``output_text``.
+
+        Examples:
+            from exa_py import AsyncExa
+
+            exa = AsyncExa("EXA_API_KEY")
+            response = await exa.responses.create(
+                model="agent",
+                input="Find companies building browser automation tools.",
+                reasoning={"effort": "low"},
+            )
+            print(response.output_text)
+        """
+        if stream:
+            raise ValueError("Streaming Responses are not supported yet.")
+
+        payload = {
+            "input": input,
+            "model": model,
+            "reasoning": reasoning,
+            "instructions": instructions,
+            "previous_response_id": previous_response_id,
+            "metadata": metadata,
+            "text": text,
+            "temperature": temperature,
+            "top_p": top_p,
+            "tools": list(tools) if tools is not None else None,
+            "tool_choice": tool_choice,
+            "max_output_tokens": max_output_tokens,
+            "store": store,
+            **kwargs,
+        }
+        response = await self._client.async_request(
+            "/v1/responses",
+            data={key: value for key, value in payload.items() if value is not None},
+            method="POST",
+        )
+        return Response.model_validate(response)
+

--- a/exa_py/responses/types.py
+++ b/exa_py/responses/types.py
@@ -1,0 +1,95 @@
+"""Types for Exa's OpenAI-compatible Responses API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional, Sequence, Union
+
+from pydantic import BaseModel, Field
+from typing_extensions import TypedDict
+
+
+AgentResponseModel = Literal["agent", "exa-agent"]
+AgentResponseEffort = Literal["low", "medium", "high", "xhigh", "auto"]
+ResponseStatus = Literal["completed", "failed", "incomplete", "queued", "running"]
+
+
+class ResponseReasoningParam(TypedDict, total=False):
+    effort: Optional[AgentResponseEffort]
+
+
+class ResponseTextFormatParam(TypedDict, total=False):
+    type: str
+    name: str
+    schema: Dict[str, Any]
+    strict: bool
+
+
+class ResponseTextConfigParam(TypedDict, total=False):
+    format: ResponseTextFormatParam
+
+
+class ResponseInputMessageParam(TypedDict, total=False):
+    role: Literal["user", "assistant", "system", "developer"]
+    content: Union[str, List[Dict[str, Any]]]
+    type: Literal["message"]
+    phase: Literal["commentary", "final_answer"]
+
+
+ResponseInputParam = Union[str, Sequence[ResponseInputMessageParam]]
+
+
+class ResponseOutputText(BaseModel):
+    type: Literal["output_text"]
+    text: str
+    annotations: List[Any] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class ResponseOutputMessage(BaseModel):
+    id: Optional[str] = None
+    type: Literal["message"]
+    status: Literal["completed", "incomplete", "in_progress"]
+    role: Literal["assistant"]
+    content: List[ResponseOutputText]
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class ResponseError(BaseModel):
+    code: Optional[str] = None
+    message: Optional[str] = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class ResponseIncompleteDetails(BaseModel):
+    reason: Optional[str] = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class Response(BaseModel):
+    id: str
+    object: Literal["response"]
+    created_at: int
+    completed_at: Optional[int] = None
+    status: ResponseStatus
+    model: str
+    output: List[ResponseOutputMessage]
+    output_text: str = ""
+    error: Optional[ResponseError] = None
+    incomplete_details: Optional[ResponseIncompleteDetails] = None
+    instructions: Optional[str] = None
+    previous_response_id: Optional[str] = None
+    metadata: Dict[str, str] = Field(default_factory=dict)
+    tools: List[Any] = Field(default_factory=list)
+    tool_choice: Any = None
+    parallel_tool_calls: Optional[bool] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    reasoning: Optional[Dict[str, Any]] = None
+    usage: Optional[Dict[str, Any]] = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+

--- a/exa_py/responses/types.py
+++ b/exa_py/responses/types.py
@@ -9,7 +9,7 @@ from typing_extensions import TypedDict
 
 
 AgentResponseModel = Literal["agent", "exa-agent"]
-AgentResponseEffort = Literal["low", "medium", "high", "xhigh", "auto"]
+AgentResponseEffort = Literal["minimal", "low", "medium", "high", "xhigh", "auto"]
 ResponseStatus = Literal["completed", "failed", "incomplete", "queued", "running"]
 
 
@@ -92,4 +92,3 @@ class Response(BaseModel):
     usage: Optional[Dict[str, Any]] = None
 
     model_config = {"populate_by_name": True, "extra": "allow"}
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.13.2" # x-release-please-version
+version = "2.13.3" # x-release-please-version
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.13.2"
+version = "2.13.3"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.13.2",
+    version="2.13.3",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -51,6 +51,45 @@ def _make_run(run_id: str = "agent_run_123") -> dict:
     }
 
 
+def _make_response() -> dict:
+    return {
+        "id": "resp_agent_run_123",
+        "object": "response",
+        "created_at": 1778706660,
+        "completed_at": 1778706684,
+        "status": "completed",
+        "model": "agent",
+        "output_text": "Returned 1 company.",
+        "output": [
+            {
+                "id": "msg_agent_run_123",
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "Returned 1 company.",
+                        "annotations": [],
+                    }
+                ],
+            }
+        ],
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "previous_response_id": None,
+        "metadata": {},
+        "tools": [],
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+        "temperature": 1,
+        "top_p": 1,
+        "reasoning": {"effort": "low", "summary": None},
+        "usage": None,
+    }
+
+
 class _MockAsyncSseResponse:
     def __init__(self, lines):
         self.lines = lines
@@ -80,6 +119,48 @@ def test_async_exa_exposes_agent_run_under_beta_namespace():
     assert hasattr(exa.beta.agent, "runs")
     assert not hasattr(exa.beta.agent, "run")
     assert not hasattr(exa, "agent")
+
+
+def test_exa_exposes_responses_namespace():
+    exa = Exa(api_key="test-api-key")
+    assert hasattr(exa, "responses")
+
+
+def test_responses_create_uses_agent_model_and_reasoning_effort(mock_client):
+    mock_client.request.return_value = _make_response()
+    responses = Exa(api_key="test-api-key").responses
+    responses._client = mock_client
+
+    result = responses.create(
+        input="Find recent funding rounds.",
+        reasoning={"effort": "low"},
+        temperature=0,
+        tools=[{"type": "function", "name": "ignored_tool"}],
+    )
+
+    assert result.id == "resp_agent_run_123"
+    assert result.output_text == "Returned 1 company."
+    mock_client.request.assert_called_once_with(
+        "/v1/responses",
+        data={
+            "input": "Find recent funding rounds.",
+            "model": "agent",
+            "reasoning": {"effort": "low"},
+            "temperature": 0,
+            "tools": [{"type": "function", "name": "ignored_tool"}],
+        },
+        method="POST",
+    )
+
+
+def test_responses_create_rejects_streaming(mock_client):
+    responses = Exa(api_key="test-api-key").responses
+    responses._client = mock_client
+
+    with pytest.raises(ValueError, match="Streaming Responses"):
+        responses.create(input="Find recent funding rounds.", stream=True)
+
+    mock_client.request.assert_not_called()
 
 
 def test_create_agent_run(run_client, mock_client):
@@ -374,6 +455,30 @@ async def test_async_agent_create():
         method="POST",
         params=None,
         headers={"Exa-Beta": AGENT_BETA_HEADER},
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_responses_create():
+    client = MagicMock()
+    client.async_request = AsyncMock(return_value=_make_response())
+    responses = AsyncExa(api_key="test-api-key").responses
+    responses._client = client
+
+    result = await responses.create(
+        input="Find recent funding rounds.",
+        reasoning={"effort": "high"},
+    )
+
+    assert result.output_text == "Returned 1 company."
+    client.async_request.assert_awaited_once_with(
+        "/v1/responses",
+        data={
+            "input": "Find recent funding rounds.",
+            "model": "agent",
+            "reasoning": {"effort": "high"},
+        },
+        method="POST",
     )
 
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -85,7 +85,7 @@ def _make_response() -> dict:
         "parallel_tool_calls": True,
         "temperature": 1,
         "top_p": 1,
-        "reasoning": {"effort": "low", "summary": None},
+        "reasoning": {"effort": "minimal", "summary": None},
         "usage": None,
     }
 
@@ -133,7 +133,7 @@ def test_responses_create_uses_agent_model_and_reasoning_effort(mock_client):
 
     result = responses.create(
         input="Find recent funding rounds.",
-        reasoning={"effort": "low"},
+        reasoning={"effort": "minimal"},
         temperature=0,
         tools=[{"type": "function", "name": "ignored_tool"}],
     )
@@ -145,7 +145,7 @@ def test_responses_create_uses_agent_model_and_reasoning_effort(mock_client):
         data={
             "input": "Find recent funding rounds.",
             "model": "agent",
-            "reasoning": {"effort": "low"},
+            "reasoning": {"effort": "minimal"},
             "temperature": 0,
             "tools": [{"type": "function", "name": "ignored_tool"}],
         },

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -141,7 +141,7 @@ def test_responses_create_uses_agent_model_and_reasoning_effort(mock_client):
     assert result.id == "resp_agent_run_123"
     assert result.output_text == "Returned 1 company."
     mock_client.request.assert_called_once_with(
-        "/v1/responses",
+        "/responses",
         data={
             "input": "Find recent funding rounds.",
             "model": "agent",
@@ -472,7 +472,7 @@ async def test_async_responses_create():
 
     assert result.output_text == "Returned 1 company."
     client.async_request.assert_awaited_once_with(
-        "/v1/responses",
+        "/responses",
         data={
             "input": "Find recent funding rounds.",
             "model": "agent",

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.13.2" # x-release-please-version
+version = "2.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary

This PR adds a first-class OpenAI-compatible Responses namespace to the Python SDK. Callers can now use `exa.responses.create(...)` and `await exa.responses.create(...)` to create non-streaming Exa Agent responses through the new `/v1/responses` API surface.

The new surface is intentionally separate from `beta.agent.runs`. It does not require Agent beta headers, defaults `model` to `"agent"`, and follows the OpenAI Responses call shape with fields like `input`, `instructions`, `previous_response_id`, `metadata`, `text`, and `reasoning`.

## Why

The backend now exposes a non-streaming Responses-compatible Agent endpoint. The Python SDK needed an idiomatic wrapper so customers do not have to instantiate the OpenAI SDK manually or construct raw HTTP calls to use Exa Agent through the Responses API shape.

## Behavior

`reasoning["effort"]` maps to Exa Agent effort modes. Supported values are `low`, `medium`, `high`, `xhigh`, and `auto`. Unsupported OpenAI-compatible generation/tool parameters like `temperature`, `top_p`, `tools`, `tool_choice`, and `max_output_tokens` are accepted and forwarded for compatibility; the backend normalizes or ignores them as appropriate.

Streaming is rejected client-side for now because the backend implementation is currently non-streaming.

## Changes

- Adds `exa_py.responses` with sync and async clients.
- Adds Pydantic response models and TypedDict request helper types.
- Wires `Exa.responses` and `AsyncExa.responses` into the top-level SDK client.
- Adds unit coverage for sync and async response creation, default `model: "agent"`, `reasoning.effort`, and streaming rejection.
- Bumps Python SDK version references from `2.13.2` to `2.13.3` and refreshes `uv.lock` per repo policy.

## Validation

- `uv run pytest tests/unit/test_agent.py`
- `uv run pytest tests/unit/`
- `uv lock`
