### PR TITLE
Remove Agent beta header requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,10 @@ for chunk in exa.stream_answer("Explain quantum computing"):
     print(chunk, end="", flush=True)
 ```
 
-## Agent API (Beta)
+## Agent API 
 
 ```python
-run = exa.beta.agent.runs.create(
-    betas=["agent-2026-05-07"],
+run = exa.agent.runs.create(
     query="Find engineering leaders at AI infrastructure companies that raised a Series A or B in the last 6 months.",
     output_schema={
         "type": "object",
@@ -149,9 +148,7 @@ run = exa.beta.agent.runs.create(
     effort="auto",
 )
 
-run = exa.beta.agent.runs.poll_until_finished(
-    run.id, betas=["agent-2026-05-07"]
-)
+run = exa.agent.runs.poll_until_finished(run.id)
 print(run.output.structured if run.output else None)
 ```
 

--- a/exa_py/agent/__init__.py
+++ b/exa_py/agent/__init__.py
@@ -1,8 +1,15 @@
 """Exa Agent API client."""
 
-from .client import AgentBetaNamespace, AgentRunsClient, AgentRunEventsClient, BetaClient
+from .client import (
+    AgentBetaNamespace,
+    AgentNamespace,
+    AgentRunsClient,
+    AgentRunEventsClient,
+    BetaClient,
+)
 from .async_client import (
     AsyncAgentBetaNamespace,
+    AsyncAgentNamespace,
     AsyncAgentRunsClient,
     AsyncAgentRunEventsClient,
     AsyncBetaClient,
@@ -30,10 +37,12 @@ from .types import (
 __all__ = [
     "AGENT_BETA_HEADER",
     "BetaClient",
+    "AgentNamespace",
     "AgentBetaNamespace",
     "AgentRunsClient",
     "AgentRunEventsClient",
     "AsyncBetaClient",
+    "AsyncAgentNamespace",
     "AsyncAgentBetaNamespace",
     "AsyncAgentRunsClient",
     "AsyncAgentRunEventsClient",

--- a/exa_py/agent/async_base.py
+++ b/exa_py/agent/async_base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import httpx
 
@@ -21,17 +21,14 @@ class AsyncAgentBaseClient:
         self,
         endpoint: str,
         *,
-        betas: Sequence[str],
         method: str = "POST",
         data: Optional[Union[Dict[str, Any], str]] = None,
         params: Optional[Dict[str, str]] = None,
         stream: bool = False,
         headers: Optional[Dict[str, str]] = None,
     ) -> Union[Dict[str, Any], httpx.Response]:
-        if not betas:
-            raise ValueError("betas must include the Agent API beta identifier")
         full_endpoint = f"{self.base_path}{endpoint}"
-        request_headers = {"Exa-Beta": ",".join(betas)}
+        request_headers = {}
         if stream:
             request_headers["Accept"] = "text/event-stream"
         if headers:

--- a/exa_py/agent/async_client.py
+++ b/exa_py/agent/async_client.py
@@ -336,7 +336,7 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
             await asyncio.sleep(poll_interval_sec)
 
 
-class AsyncAgentBetaRunEventsClient(AsyncAgentBaseClient):
+class AsyncAgentBetaRunEventsClient(AsyncAgentRunEventsClient):
     """Deprecated compatibility wrapper for asynchronous Agent run events."""
 
     async def list(
@@ -357,7 +357,7 @@ class AsyncAgentBetaRunEventsClient(AsyncAgentBaseClient):
         return ListAgentRunEventsResponse.model_validate(response)
 
 
-class AsyncAgentBetaRunsClient(AsyncAgentBaseClient):
+class AsyncAgentBetaRunsClient(AsyncAgentRunsClient):
     """Deprecated compatibility wrapper for asynchronous Agent runs."""
 
     events: AsyncAgentBetaRunEventsClient
@@ -522,12 +522,13 @@ class AsyncAgentNamespace:
         self.runs = AsyncAgentRunsClient(client)
 
 
-class AsyncAgentBetaNamespace:
+class AsyncAgentBetaNamespace(AsyncAgentNamespace):
     """Deprecated compatibility wrapper for the asynchronous Agent namespace."""
 
     runs: AsyncAgentBetaRunsClient
 
     def __init__(self, client: Any):
+        super().__init__(client)
         self.runs = AsyncAgentBetaRunsClient(client)
 
 

--- a/exa_py/agent/async_client.py
+++ b/exa_py/agent/async_client.py
@@ -17,16 +17,13 @@ from typing import (
 
 from pydantic import BaseModel
 
-from exa_py.utils import _convert_schema_input
-
 from .async_base import AsyncAgentBaseClient
-from .client import _is_pydantic_model
+from .client import _build_create_payload, _headers_for_betas
 from .types import (
     AgentEvent,
     AgentEffort,
     AgentInput,
     AgentRun,
-    CreateAgentRunParams,
     DeletedAgentRun,
     ListAgentRunEventsResponse,
     ListAgentRunsResponse,
@@ -41,7 +38,6 @@ class AsyncAgentRunEventsClient(AsyncAgentBaseClient):
         self,
         run_id: str,
         *,
-        betas: Sequence[str],
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> ListAgentRunEventsResponse:
@@ -49,7 +45,6 @@ class AsyncAgentRunEventsClient(AsyncAgentBaseClient):
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
             cursor: Pagination cursor from a previous response.
             limit: Maximum number of events to return.
 
@@ -61,17 +56,14 @@ class AsyncAgentRunEventsClient(AsyncAgentBaseClient):
 
             exa = AsyncExa("EXA_API_KEY")
 
-            events = await exa.beta.agent.runs.events.list(
+            events = await exa.agent.runs.events.list(
                 "agent_run_123",
-                betas=["agent-2026-05-07"],
                 limit=20,
             )
             print(events.data[0].event if events.data else "no events yet")
         """
         params = self.build_pagination_params(cursor, limit)
-        response = await self.request(
-            f"/{run_id}/events", betas=betas, method="GET", params=params
-        )
+        response = await self.request(f"/{run_id}/events", method="GET", params=params)
         return ListAgentRunEventsResponse.model_validate(response)
 
 
@@ -88,7 +80,6 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
     async def create(
         self,
         *,
-        betas: Sequence[str],
         query: str,
         system_prompt: Optional[str] = None,
         input: Optional[Union[Dict[str, Any], AgentInput]] = None,
@@ -103,7 +94,6 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
     async def create(
         self,
         *,
-        betas: Sequence[str],
         query: str,
         system_prompt: Optional[str] = None,
         input: Optional[Union[Dict[str, Any], AgentInput]] = None,
@@ -117,7 +107,6 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
     async def create(
         self,
         *,
-        betas: Sequence[str],
         query: str,
         system_prompt: Optional[str] = None,
         input: Optional[Union[Dict[str, Any], AgentInput]] = None,
@@ -130,7 +119,6 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
         """Create an Agent run.
 
         Args:
-            betas: Beta feature identifiers to enable for this request.
             query: The task or question for the Agent run.
             system_prompt: Optional instructions that steer the Agent.
             input: Optional structured input data for the Agent.
@@ -148,45 +136,31 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
 
             exa = AsyncExa("EXA_API_KEY")
 
-            run = await exa.beta.agent.runs.create(
-                betas=["agent-2026-05-07"],
+            run = await exa.agent.runs.create(
                 query="Find companies building browser automation tools",
             )
             print(run.id)
         """
-        schema = (
-            _convert_schema_input(output_schema)
-            if _is_pydantic_model(output_schema)
-            else output_schema
-        )
-        run_input = (
-            input
-            if isinstance(input, AgentInput) or input is None
-            else AgentInput.model_validate(input)
-        )
-        payload = CreateAgentRunParams(
+        payload = _build_create_payload(
             query=query,
             system_prompt=system_prompt,
-            input=run_input,
-            output_schema=schema,
+            input=input,
+            output_schema=output_schema,
             effort=effort,
             previous_run_id=previous_run_id,
             metadata=metadata,
-        ).model_dump(by_alias=True, exclude_none=True)
-
-        response = await self.request(
-            "", betas=betas, method="POST", data=payload, stream=stream
         )
+
+        response = await self.request("", method="POST", data=payload, stream=stream)
         if stream:
             return async_stream_agent_events(response)
         return AgentRun.model_validate(response)
 
-    async def get(self, run_id: str, *, betas: Sequence[str]) -> AgentRun:
+    async def get(self, run_id: str) -> AgentRun:
         """Get an Agent run by ID.
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
 
         Returns:
             The Agent run.
@@ -196,26 +170,21 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
 
             exa = AsyncExa("EXA_API_KEY")
 
-            run = await exa.beta.agent.runs.get(
-                "agent_run_123",
-                betas=["agent-2026-05-07"],
-            )
+            run = await exa.agent.runs.get("agent_run_123")
             print(run.status)
         """
-        response = await self.request(f"/{run_id}", betas=betas, method="GET")
+        response = await self.request(f"/{run_id}", method="GET")
         return AgentRun.model_validate(response)
 
     async def list(
         self,
         *,
-        betas: Sequence[str],
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> ListAgentRunsResponse:
         """List Agent runs.
 
         Args:
-            betas: Beta feature identifiers to enable for this request.
             cursor: Pagination cursor from a previous response.
             limit: Maximum number of runs to return.
 
@@ -227,26 +196,21 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
 
             exa = AsyncExa("EXA_API_KEY")
 
-            runs = await exa.beta.agent.runs.list(
-                betas=["agent-2026-05-07"],
-                limit=10,
-            )
+            runs = await exa.agent.runs.list(limit=10)
             print([run.id for run in runs.data])
         """
         params = self.build_pagination_params(cursor, limit)
-        response = await self.request("", betas=betas, method="GET", params=params)
+        response = await self.request("", method="GET", params=params)
         return ListAgentRunsResponse.model_validate(response)
 
     async def list_all(
         self,
         *,
-        betas: Sequence[str],
         limit: Optional[int] = None,
     ) -> AsyncGenerator[AgentRun, None]:
         """Iterate through all Agent runs, handling pagination automatically.
 
         Args:
-            betas: Beta feature identifiers to enable for this request.
             limit: Maximum number of runs to return per page.
 
         Yields:
@@ -257,27 +221,22 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
 
             exa = AsyncExa("EXA_API_KEY")
 
-            async for run in exa.beta.agent.runs.list_all(
-                betas=["agent-2026-05-07"],
-            ):
+            async for run in exa.agent.runs.list_all():
                 print(run.id)
         """
         cursor = None
         while True:
-            response = await self.list(betas=betas, cursor=cursor, limit=limit)
+            response = await self.list(cursor=cursor, limit=limit)
             for run in response.data:
                 yield run
             if not response.has_more or not response.next_cursor:
                 break
             cursor = response.next_cursor
 
-    async def get_all(
-        self, *, betas: Sequence[str], limit: Optional[int] = None
-    ) -> list[AgentRun]:
+    async def get_all(self, *, limit: Optional[int] = None) -> list[AgentRun]:
         """Collect all Agent runs into a list.
 
         Args:
-            betas: Beta feature identifiers to enable for this request.
             limit: Maximum number of runs to return per page.
 
         Returns:
@@ -288,22 +247,19 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
 
             exa = AsyncExa("EXA_API_KEY")
 
-            runs = await exa.beta.agent.runs.get_all(
-                betas=["agent-2026-05-07"],
-            )
+            runs = await exa.agent.runs.get_all()
             print(len(runs))
         """
         runs: list[AgentRun] = []
-        async for run in self.list_all(betas=betas, limit=limit):
+        async for run in self.list_all(limit=limit):
             runs.append(run)
         return runs
 
-    async def cancel(self, run_id: str, *, betas: Sequence[str]) -> AgentRun:
+    async def cancel(self, run_id: str) -> AgentRun:
         """Cancel a queued or running Agent run.
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
 
         Returns:
             The cancelled Agent run.
@@ -313,21 +269,17 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
 
             exa = AsyncExa("EXA_API_KEY")
 
-            run = await exa.beta.agent.runs.cancel(
-                "agent_run_123",
-                betas=["agent-2026-05-07"],
-            )
+            run = await exa.agent.runs.cancel("agent_run_123")
             print(run.status)
         """
-        response = await self.request(f"/{run_id}/cancel", betas=betas, method="POST")
+        response = await self.request(f"/{run_id}/cancel", method="POST")
         return AgentRun.model_validate(response)
 
-    async def delete(self, run_id: str, *, betas: Sequence[str]) -> DeletedAgentRun:
+    async def delete(self, run_id: str) -> DeletedAgentRun:
         """Delete an Agent run.
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
 
         Returns:
             Deletion status for the Agent run.
@@ -337,20 +289,16 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
 
             exa = AsyncExa("EXA_API_KEY")
 
-            deleted = await exa.beta.agent.runs.delete(
-                "agent_run_123",
-                betas=["agent-2026-05-07"],
-            )
+            deleted = await exa.agent.runs.delete("agent_run_123")
             print(deleted.deleted)
         """
-        response = await self.request(f"/{run_id}", betas=betas, method="DELETE")
+        response = await self.request(f"/{run_id}", method="DELETE")
         return DeletedAgentRun.model_validate(response)
 
     async def poll_until_finished(
         self,
         run_id: str,
         *,
-        betas: Sequence[str],
         poll_interval: int = 1000,
         timeout_ms: int = 3600000,
     ) -> AgentRun:
@@ -358,7 +306,6 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
             poll_interval: Delay between polls in milliseconds.
             timeout_ms: Maximum time to wait in milliseconds.
 
@@ -370,12 +317,186 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
 
             exa = AsyncExa("EXA_API_KEY")
 
-            run = await exa.beta.agent.runs.poll_until_finished(
-                "agent_run_123",
-                betas=["agent-2026-05-07"],
-            )
+            run = await exa.agent.runs.poll_until_finished("agent_run_123")
             print(run.status)
         """
+        start_time = asyncio.get_event_loop().time()
+        poll_interval_sec = poll_interval / 1000
+
+        while True:
+            run = await self.get(run_id)
+            if run.status in ("completed", "failed", "cancelled"):
+                return run
+
+            if (asyncio.get_event_loop().time() - start_time) * 1000 > timeout_ms:
+                raise TimeoutError(
+                    f"Agent run {run_id} did not complete within {timeout_ms}ms"
+                )
+
+            await asyncio.sleep(poll_interval_sec)
+
+
+class AsyncAgentBetaRunEventsClient(AsyncAgentBaseClient):
+    """Deprecated compatibility wrapper for asynchronous Agent run events."""
+
+    async def list(
+        self,
+        run_id: str,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> ListAgentRunEventsResponse:
+        params = self.build_pagination_params(cursor, limit)
+        response = await self.request(
+            f"/{run_id}/events",
+            method="GET",
+            params=params,
+            headers=_headers_for_betas(betas),
+        )
+        return ListAgentRunEventsResponse.model_validate(response)
+
+
+class AsyncAgentBetaRunsClient(AsyncAgentBaseClient):
+    """Deprecated compatibility wrapper for asynchronous Agent runs."""
+
+    events: AsyncAgentBetaRunEventsClient
+
+    def __init__(self, client: Any):
+        super().__init__(client)
+        self.events = AsyncAgentBetaRunEventsClient(client)
+
+    @overload
+    async def create(
+        self,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        query: str,
+        system_prompt: Optional[str] = None,
+        input: Optional[Union[Dict[str, Any], AgentInput]] = None,
+        output_schema: Optional[Union[Dict[str, Any], Type[BaseModel]]] = None,
+        effort: Optional[AgentEffort] = None,
+        previous_run_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        stream: Literal[False] = False,
+    ) -> AgentRun: ...
+
+    @overload
+    async def create(
+        self,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        query: str,
+        system_prompt: Optional[str] = None,
+        input: Optional[Union[Dict[str, Any], AgentInput]] = None,
+        output_schema: Optional[Union[Dict[str, Any], Type[BaseModel]]] = None,
+        effort: Optional[AgentEffort] = None,
+        previous_run_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        stream: Literal[True] = True,
+    ) -> AsyncGenerator[AgentEvent, None]: ...
+
+    async def create(
+        self,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        query: str,
+        system_prompt: Optional[str] = None,
+        input: Optional[Union[Dict[str, Any], AgentInput]] = None,
+        output_schema: Optional[Union[Dict[str, Any], Type[BaseModel]]] = None,
+        effort: Optional[AgentEffort] = None,
+        previous_run_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        stream: bool = False,
+    ) -> Union[AgentRun, AsyncGenerator[AgentEvent, None]]:
+        payload = _build_create_payload(
+            query=query,
+            system_prompt=system_prompt,
+            input=input,
+            output_schema=output_schema,
+            effort=effort,
+            previous_run_id=previous_run_id,
+            metadata=metadata,
+        )
+        response = await self.request(
+            "",
+            method="POST",
+            data=payload,
+            stream=stream,
+            headers=_headers_for_betas(betas),
+        )
+        if stream:
+            return async_stream_agent_events(response)
+        return AgentRun.model_validate(response)
+
+    async def get(
+        self, run_id: str, *, betas: Optional[Sequence[str]] = None
+    ) -> AgentRun:
+        response = await self.request(
+            f"/{run_id}", method="GET", headers=_headers_for_betas(betas)
+        )
+        return AgentRun.model_validate(response)
+
+    async def list(
+        self,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> ListAgentRunsResponse:
+        params = self.build_pagination_params(cursor, limit)
+        response = await self.request(
+            "", method="GET", params=params, headers=_headers_for_betas(betas)
+        )
+        return ListAgentRunsResponse.model_validate(response)
+
+    async def list_all(
+        self,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        limit: Optional[int] = None,
+    ) -> AsyncGenerator[AgentRun, None]:
+        cursor = None
+        while True:
+            response = await self.list(betas=betas, cursor=cursor, limit=limit)
+            for run in response.data:
+                yield run
+            if not response.has_more or not response.next_cursor:
+                break
+            cursor = response.next_cursor
+
+    async def get_all(
+        self, *, betas: Optional[Sequence[str]] = None, limit: Optional[int] = None
+    ) -> list[AgentRun]:
+        runs: list[AgentRun] = []
+        async for run in self.list_all(betas=betas, limit=limit):
+            runs.append(run)
+        return runs
+
+    async def cancel(
+        self, run_id: str, *, betas: Optional[Sequence[str]] = None
+    ) -> AgentRun:
+        response = await self.request(
+            f"/{run_id}/cancel", method="POST", headers=_headers_for_betas(betas)
+        )
+        return AgentRun.model_validate(response)
+
+    async def delete(
+        self, run_id: str, *, betas: Optional[Sequence[str]] = None
+    ) -> DeletedAgentRun:
+        response = await self.request(
+            f"/{run_id}", method="DELETE", headers=_headers_for_betas(betas)
+        )
+        return DeletedAgentRun.model_validate(response)
+
+    async def poll_until_finished(
+        self,
+        run_id: str,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        poll_interval: int = 1000,
+        timeout_ms: int = 3600000,
+    ) -> AgentRun:
         start_time = asyncio.get_event_loop().time()
         poll_interval_sec = poll_interval / 1000
 
@@ -392,8 +513,8 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
             await asyncio.sleep(poll_interval_sec)
 
 
-class AsyncAgentBetaNamespace:
-    """Asynchronous beta Agent namespace."""
+class AsyncAgentNamespace:
+    """Asynchronous Agent namespace."""
 
     runs: AsyncAgentRunsClient
 
@@ -401,8 +522,17 @@ class AsyncAgentBetaNamespace:
         self.runs = AsyncAgentRunsClient(client)
 
 
+class AsyncAgentBetaNamespace:
+    """Deprecated compatibility wrapper for the asynchronous Agent namespace."""
+
+    runs: AsyncAgentBetaRunsClient
+
+    def __init__(self, client: Any):
+        self.runs = AsyncAgentBetaRunsClient(client)
+
+
 class AsyncBetaClient:
-    """Asynchronous beta namespace."""
+    """Deprecated asynchronous beta namespace."""
 
     agent: AsyncAgentBetaNamespace
 

--- a/exa_py/agent/base.py
+++ b/exa_py/agent/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import requests
 
@@ -21,17 +21,14 @@ class AgentBaseClient:
         self,
         endpoint: str,
         *,
-        betas: Sequence[str],
         method: str = "POST",
         data: Optional[Union[Dict[str, Any], str]] = None,
         params: Optional[Dict[str, str]] = None,
         stream: bool = False,
         headers: Optional[Dict[str, str]] = None,
     ) -> Union[Dict[str, Any], requests.Response]:
-        if not betas:
-            raise ValueError("betas must include the Agent API beta identifier")
         full_endpoint = f"{self.base_path}{endpoint}"
-        request_headers = {"Exa-Beta": ",".join(betas)}
+        request_headers = {}
         if stream:
             request_headers["Accept"] = "text/event-stream"
         if headers:

--- a/exa_py/agent/client.py
+++ b/exa_py/agent/client.py
@@ -381,7 +381,7 @@ class AgentRunsClient(AgentBaseClient):
             time.sleep(poll_interval_sec)
 
 
-class AgentBetaRunEventsClient(AgentBaseClient):
+class AgentBetaRunEventsClient(AgentRunEventsClient):
     """Deprecated compatibility wrapper for Agent run events."""
 
     def list(
@@ -402,7 +402,7 @@ class AgentBetaRunEventsClient(AgentBaseClient):
         return ListAgentRunEventsResponse.model_validate(response)
 
 
-class AgentBetaRunsClient(AgentBaseClient):
+class AgentBetaRunsClient(AgentRunsClient):
     """Deprecated compatibility wrapper for Agent runs."""
 
     events: AgentBetaRunEventsClient
@@ -561,12 +561,13 @@ class AgentNamespace:
         self.runs = AgentRunsClient(client)
 
 
-class AgentBetaNamespace:
+class AgentBetaNamespace(AgentNamespace):
     """Deprecated compatibility wrapper for the synchronous Agent namespace."""
 
     runs: AgentBetaRunsClient
 
     def __init__(self, client: Any):
+        super().__init__(client)
         self.runs = AgentBetaRunsClient(client)
 
 

--- a/exa_py/agent/client.py
+++ b/exa_py/agent/client.py
@@ -41,6 +41,48 @@ def _is_pydantic_model(schema: Any) -> bool:
         return False
 
 
+def _headers_for_betas(betas: Optional[Sequence[str]]) -> Optional[Dict[str, str]]:
+    if not betas:
+        return None
+
+    beta_values = [beta for beta in betas if beta]
+    if not beta_values:
+        return None
+
+    return {"Exa-Beta": ",".join(beta_values)}
+
+
+def _build_create_payload(
+    *,
+    query: str,
+    system_prompt: Optional[str] = None,
+    input: Optional[Union[Dict[str, Any], AgentInput]] = None,
+    output_schema: Optional[Union[Dict[str, Any], Type[BaseModel]]] = None,
+    effort: Optional[AgentEffort] = None,
+    previous_run_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    schema = (
+        _convert_schema_input(output_schema)
+        if _is_pydantic_model(output_schema)
+        else output_schema
+    )
+    run_input = (
+        input
+        if isinstance(input, AgentInput) or input is None
+        else AgentInput.model_validate(input)
+    )
+    return CreateAgentRunParams(
+        query=query,
+        system_prompt=system_prompt,
+        input=run_input,
+        output_schema=schema,
+        effort=effort,
+        previous_run_id=previous_run_id,
+        metadata=metadata,
+    ).model_dump(by_alias=True, exclude_none=True)
+
+
 class AgentRunEventsClient(AgentBaseClient):
     """Synchronous client for Agent run events."""
 
@@ -48,7 +90,6 @@ class AgentRunEventsClient(AgentBaseClient):
         self,
         run_id: str,
         *,
-        betas: Sequence[str],
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> ListAgentRunEventsResponse:
@@ -56,7 +97,6 @@ class AgentRunEventsClient(AgentBaseClient):
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
             cursor: Pagination cursor from a previous response.
             limit: Maximum number of events to return.
 
@@ -68,17 +108,14 @@ class AgentRunEventsClient(AgentBaseClient):
 
             exa = Exa("EXA_API_KEY")
 
-            events = exa.beta.agent.runs.events.list(
+            events = exa.agent.runs.events.list(
                 "agent_run_123",
-                betas=["agent-2026-05-07"],
                 limit=20,
             )
             print(events.data[0].event if events.data else "no events yet")
         """
         params = self.build_pagination_params(cursor, limit)
-        response = self.request(
-            f"/{run_id}/events", betas=betas, method="GET", params=params
-        )
+        response = self.request(f"/{run_id}/events", method="GET", params=params)
         return ListAgentRunEventsResponse.model_validate(response)
 
 
@@ -95,7 +132,6 @@ class AgentRunsClient(AgentBaseClient):
     def create(
         self,
         *,
-        betas: Sequence[str],
         query: str,
         system_prompt: Optional[str] = None,
         input: Optional[Union[Dict[str, Any], AgentInput]] = None,
@@ -110,7 +146,6 @@ class AgentRunsClient(AgentBaseClient):
     def create(
         self,
         *,
-        betas: Sequence[str],
         query: str,
         system_prompt: Optional[str] = None,
         input: Optional[Union[Dict[str, Any], AgentInput]] = None,
@@ -124,7 +159,6 @@ class AgentRunsClient(AgentBaseClient):
     def create(
         self,
         *,
-        betas: Sequence[str],
         query: str,
         system_prompt: Optional[str] = None,
         input: Optional[Union[Dict[str, Any], AgentInput]] = None,
@@ -137,7 +171,6 @@ class AgentRunsClient(AgentBaseClient):
         """Create an Agent run.
 
         Args:
-            betas: Beta feature identifiers to enable for this request.
             query: The task or question for the Agent run.
             system_prompt: Optional instructions that steer the Agent.
             input: Optional structured input data for the Agent.
@@ -155,45 +188,31 @@ class AgentRunsClient(AgentBaseClient):
 
             exa = Exa("EXA_API_KEY")
 
-            run = exa.beta.agent.runs.create(
-                betas=["agent-2026-05-07"],
+            run = exa.agent.runs.create(
                 query="Find companies building browser automation tools",
             )
             print(run.id)
         """
-        schema = (
-            _convert_schema_input(output_schema)
-            if _is_pydantic_model(output_schema)
-            else output_schema
-        )
-        run_input = (
-            input
-            if isinstance(input, AgentInput) or input is None
-            else AgentInput.model_validate(input)
-        )
-        payload = CreateAgentRunParams(
+        payload = _build_create_payload(
             query=query,
             system_prompt=system_prompt,
-            input=run_input,
-            output_schema=schema,
+            input=input,
+            output_schema=output_schema,
             effort=effort,
             previous_run_id=previous_run_id,
             metadata=metadata,
-        ).model_dump(by_alias=True, exclude_none=True)
-
-        response = self.request(
-            "", betas=betas, method="POST", data=payload, stream=stream
         )
+
+        response = self.request("", method="POST", data=payload, stream=stream)
         if stream:
             return stream_agent_events(response)
         return AgentRun.model_validate(response)
 
-    def get(self, run_id: str, *, betas: Sequence[str]) -> AgentRun:
+    def get(self, run_id: str) -> AgentRun:
         """Get an Agent run by ID.
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
 
         Returns:
             The Agent run.
@@ -203,26 +222,21 @@ class AgentRunsClient(AgentBaseClient):
 
             exa = Exa("EXA_API_KEY")
 
-            run = exa.beta.agent.runs.get(
-                "agent_run_123",
-                betas=["agent-2026-05-07"],
-            )
+            run = exa.agent.runs.get("agent_run_123")
             print(run.status)
         """
-        response = self.request(f"/{run_id}", betas=betas, method="GET")
+        response = self.request(f"/{run_id}", method="GET")
         return AgentRun.model_validate(response)
 
     def list(
         self,
         *,
-        betas: Sequence[str],
         cursor: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> ListAgentRunsResponse:
         """List Agent runs.
 
         Args:
-            betas: Beta feature identifiers to enable for this request.
             cursor: Pagination cursor from a previous response.
             limit: Maximum number of runs to return.
 
@@ -234,23 +248,17 @@ class AgentRunsClient(AgentBaseClient):
 
             exa = Exa("EXA_API_KEY")
 
-            runs = exa.beta.agent.runs.list(
-                betas=["agent-2026-05-07"],
-                limit=10,
-            )
+            runs = exa.agent.runs.list(limit=10)
             print([run.id for run in runs.data])
         """
         params = self.build_pagination_params(cursor, limit)
-        response = self.request("", betas=betas, method="GET", params=params)
+        response = self.request("", method="GET", params=params)
         return ListAgentRunsResponse.model_validate(response)
 
-    def list_all(
-        self, *, betas: Sequence[str], limit: Optional[int] = None
-    ) -> Iterator[AgentRun]:
+    def list_all(self, *, limit: Optional[int] = None) -> Iterator[AgentRun]:
         """Iterate through all Agent runs, handling pagination automatically.
 
         Args:
-            betas: Beta feature identifiers to enable for this request.
             limit: Maximum number of runs to return per page.
 
         Yields:
@@ -261,27 +269,22 @@ class AgentRunsClient(AgentBaseClient):
 
             exa = Exa("EXA_API_KEY")
 
-            for run in exa.beta.agent.runs.list_all(
-                betas=["agent-2026-05-07"],
-            ):
+            for run in exa.agent.runs.list_all():
                 print(run.id)
         """
         cursor = None
         while True:
-            response = self.list(betas=betas, cursor=cursor, limit=limit)
+            response = self.list(cursor=cursor, limit=limit)
             for run in response.data:
                 yield run
             if not response.has_more or not response.next_cursor:
                 break
             cursor = response.next_cursor
 
-    def get_all(
-        self, *, betas: Sequence[str], limit: Optional[int] = None
-    ) -> list[AgentRun]:
+    def get_all(self, *, limit: Optional[int] = None) -> list[AgentRun]:
         """Collect all Agent runs into a list.
 
         Args:
-            betas: Beta feature identifiers to enable for this request.
             limit: Maximum number of runs to return per page.
 
         Returns:
@@ -292,19 +295,16 @@ class AgentRunsClient(AgentBaseClient):
 
             exa = Exa("EXA_API_KEY")
 
-            runs = exa.beta.agent.runs.get_all(
-                betas=["agent-2026-05-07"],
-            )
+            runs = exa.agent.runs.get_all()
             print(len(runs))
         """
-        return list(self.list_all(betas=betas, limit=limit))
+        return list(self.list_all(limit=limit))
 
-    def cancel(self, run_id: str, *, betas: Sequence[str]) -> AgentRun:
+    def cancel(self, run_id: str) -> AgentRun:
         """Cancel a queued or running Agent run.
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
 
         Returns:
             The cancelled Agent run.
@@ -314,21 +314,17 @@ class AgentRunsClient(AgentBaseClient):
 
             exa = Exa("EXA_API_KEY")
 
-            run = exa.beta.agent.runs.cancel(
-                "agent_run_123",
-                betas=["agent-2026-05-07"],
-            )
+            run = exa.agent.runs.cancel("agent_run_123")
             print(run.status)
         """
-        response = self.request(f"/{run_id}/cancel", betas=betas, method="POST")
+        response = self.request(f"/{run_id}/cancel", method="POST")
         return AgentRun.model_validate(response)
 
-    def delete(self, run_id: str, *, betas: Sequence[str]) -> DeletedAgentRun:
+    def delete(self, run_id: str) -> DeletedAgentRun:
         """Delete an Agent run.
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
 
         Returns:
             Deletion status for the Agent run.
@@ -338,20 +334,16 @@ class AgentRunsClient(AgentBaseClient):
 
             exa = Exa("EXA_API_KEY")
 
-            deleted = exa.beta.agent.runs.delete(
-                "agent_run_123",
-                betas=["agent-2026-05-07"],
-            )
+            deleted = exa.agent.runs.delete("agent_run_123")
             print(deleted.deleted)
         """
-        response = self.request(f"/{run_id}", betas=betas, method="DELETE")
+        response = self.request(f"/{run_id}", method="DELETE")
         return DeletedAgentRun.model_validate(response)
 
     def poll_until_finished(
         self,
         run_id: str,
         *,
-        betas: Sequence[str],
         poll_interval: int = 1000,
         timeout_ms: int = 3600000,
     ) -> AgentRun:
@@ -359,7 +351,6 @@ class AgentRunsClient(AgentBaseClient):
 
         Args:
             run_id: The ID of the Agent run.
-            betas: Beta feature identifiers to enable for this request.
             poll_interval: Delay between polls in milliseconds.
             timeout_ms: Maximum time to wait in milliseconds.
 
@@ -371,12 +362,180 @@ class AgentRunsClient(AgentBaseClient):
 
             exa = Exa("EXA_API_KEY")
 
-            run = exa.beta.agent.runs.poll_until_finished(
-                "agent_run_123",
-                betas=["agent-2026-05-07"],
-            )
+            run = exa.agent.runs.poll_until_finished("agent_run_123")
             print(run.status)
         """
+        start_time = time.monotonic()
+        poll_interval_sec = poll_interval / 1000
+
+        while True:
+            run = self.get(run_id)
+            if run.status in ("completed", "failed", "cancelled"):
+                return run
+
+            if (time.monotonic() - start_time) * 1000 > timeout_ms:
+                raise TimeoutError(
+                    f"Agent run {run_id} did not complete within {timeout_ms}ms"
+                )
+
+            time.sleep(poll_interval_sec)
+
+
+class AgentBetaRunEventsClient(AgentBaseClient):
+    """Deprecated compatibility wrapper for Agent run events."""
+
+    def list(
+        self,
+        run_id: str,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> ListAgentRunEventsResponse:
+        params = self.build_pagination_params(cursor, limit)
+        response = self.request(
+            f"/{run_id}/events",
+            method="GET",
+            params=params,
+            headers=_headers_for_betas(betas),
+        )
+        return ListAgentRunEventsResponse.model_validate(response)
+
+
+class AgentBetaRunsClient(AgentBaseClient):
+    """Deprecated compatibility wrapper for Agent runs."""
+
+    events: AgentBetaRunEventsClient
+
+    def __init__(self, client: Any):
+        super().__init__(client)
+        self.events = AgentBetaRunEventsClient(client)
+
+    @overload
+    def create(
+        self,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        query: str,
+        system_prompt: Optional[str] = None,
+        input: Optional[Union[Dict[str, Any], AgentInput]] = None,
+        output_schema: Optional[Union[Dict[str, Any], Type[BaseModel]]] = None,
+        effort: Optional[AgentEffort] = None,
+        previous_run_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        stream: Literal[False] = False,
+    ) -> AgentRun: ...
+
+    @overload
+    def create(
+        self,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        query: str,
+        system_prompt: Optional[str] = None,
+        input: Optional[Union[Dict[str, Any], AgentInput]] = None,
+        output_schema: Optional[Union[Dict[str, Any], Type[BaseModel]]] = None,
+        effort: Optional[AgentEffort] = None,
+        previous_run_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        stream: Literal[True] = True,
+    ) -> Generator[AgentEvent, None, None]: ...
+
+    def create(
+        self,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        query: str,
+        system_prompt: Optional[str] = None,
+        input: Optional[Union[Dict[str, Any], AgentInput]] = None,
+        output_schema: Optional[Union[Dict[str, Any], Type[BaseModel]]] = None,
+        effort: Optional[AgentEffort] = None,
+        previous_run_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        stream: bool = False,
+    ) -> Union[AgentRun, Generator[AgentEvent, None, None]]:
+        payload = _build_create_payload(
+            query=query,
+            system_prompt=system_prompt,
+            input=input,
+            output_schema=output_schema,
+            effort=effort,
+            previous_run_id=previous_run_id,
+            metadata=metadata,
+        )
+        response = self.request(
+            "",
+            method="POST",
+            data=payload,
+            stream=stream,
+            headers=_headers_for_betas(betas),
+        )
+        if stream:
+            return stream_agent_events(response)
+        return AgentRun.model_validate(response)
+
+    def get(
+        self, run_id: str, *, betas: Optional[Sequence[str]] = None
+    ) -> AgentRun:
+        response = self.request(
+            f"/{run_id}", method="GET", headers=_headers_for_betas(betas)
+        )
+        return AgentRun.model_validate(response)
+
+    def list(
+        self,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> ListAgentRunsResponse:
+        params = self.build_pagination_params(cursor, limit)
+        response = self.request(
+            "", method="GET", params=params, headers=_headers_for_betas(betas)
+        )
+        return ListAgentRunsResponse.model_validate(response)
+
+    def list_all(
+        self, *, betas: Optional[Sequence[str]] = None, limit: Optional[int] = None
+    ) -> Iterator[AgentRun]:
+        cursor = None
+        while True:
+            response = self.list(betas=betas, cursor=cursor, limit=limit)
+            for run in response.data:
+                yield run
+            if not response.has_more or not response.next_cursor:
+                break
+            cursor = response.next_cursor
+
+    def get_all(
+        self, *, betas: Optional[Sequence[str]] = None, limit: Optional[int] = None
+    ) -> list[AgentRun]:
+        return list(self.list_all(betas=betas, limit=limit))
+
+    def cancel(
+        self, run_id: str, *, betas: Optional[Sequence[str]] = None
+    ) -> AgentRun:
+        response = self.request(
+            f"/{run_id}/cancel", method="POST", headers=_headers_for_betas(betas)
+        )
+        return AgentRun.model_validate(response)
+
+    def delete(
+        self, run_id: str, *, betas: Optional[Sequence[str]] = None
+    ) -> DeletedAgentRun:
+        response = self.request(
+            f"/{run_id}", method="DELETE", headers=_headers_for_betas(betas)
+        )
+        return DeletedAgentRun.model_validate(response)
+
+    def poll_until_finished(
+        self,
+        run_id: str,
+        *,
+        betas: Optional[Sequence[str]] = None,
+        poll_interval: int = 1000,
+        timeout_ms: int = 3600000,
+    ) -> AgentRun:
         start_time = time.monotonic()
         poll_interval_sec = poll_interval / 1000
 
@@ -393,8 +552,8 @@ class AgentRunsClient(AgentBaseClient):
             time.sleep(poll_interval_sec)
 
 
-class AgentBetaNamespace:
-    """Synchronous beta Agent namespace."""
+class AgentNamespace:
+    """Synchronous Agent namespace."""
 
     runs: AgentRunsClient
 
@@ -402,8 +561,17 @@ class AgentBetaNamespace:
         self.runs = AgentRunsClient(client)
 
 
+class AgentBetaNamespace:
+    """Deprecated compatibility wrapper for the synchronous Agent namespace."""
+
+    runs: AgentBetaRunsClient
+
+    def __init__(self, client: Any):
+        self.runs = AgentBetaRunsClient(client)
+
+
 class BetaClient:
-    """Synchronous beta namespace."""
+    """Deprecated synchronous beta namespace."""
 
     agent: AgentBetaNamespace
 

--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -44,7 +44,7 @@ from .websets import WebsetsClient
 from .websets.core.base import ExaJSONEncoder
 from .monitors import SearchMonitorsClient, AsyncSearchMonitorsClient
 from .research import ResearchClient, AsyncResearchClient
-from .agent import BetaClient, AsyncBetaClient
+from .agent import AgentNamespace, AsyncAgentNamespace, BetaClient, AsyncBetaClient
 
 
 is_beta = os.getenv("IS_BETA") == "True"
@@ -1459,7 +1459,8 @@ class Exa:
         self.research = ResearchClient(self)
         # Search Monitors client
         self.monitors = SearchMonitorsClient(self)
-        # Beta clients
+        # Agent clients
+        self.agent = AgentNamespace(self)
         self.beta = BetaClient(self)
 
     def request(
@@ -2661,7 +2662,8 @@ class AsyncExa(Exa):
         self.websets = AsyncWebsetsClient(self)
         # Override the synchronous SearchMonitorsClient with its async counterpart.
         self.monitors = AsyncSearchMonitorsClient(self)
-        # Override the synchronous beta clients with async counterparts.
+        # Override the synchronous Agent clients with async counterparts.
+        self.agent = AsyncAgentNamespace(self)
         self.beta = AsyncBetaClient(self)
         self._client = None
 

--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -1422,9 +1422,6 @@ def nest_fields(original_dict: Dict, fields_to_nest: List[str], new_key: str):
 class Exa:
     """A client for interacting with Exa API."""
 
-    agent: AgentNamespace
-    beta: BetaClient
-
     def __init__(
         self,
         api_key: Optional[str],
@@ -2657,9 +2654,6 @@ class Exa:
 
 
 class AsyncExa(Exa):
-    agent: AsyncAgentNamespace  # type: ignore[assignment]
-    beta: AsyncBetaClient  # type: ignore[assignment]
-
     def __init__(self, api_key: str, api_base: str = "https://api.exa.ai"):
         super().__init__(api_key, api_base)
         # Override the synchronous ResearchClient with its async counterpart.

--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -1422,6 +1422,9 @@ def nest_fields(original_dict: Dict, fields_to_nest: List[str], new_key: str):
 class Exa:
     """A client for interacting with Exa API."""
 
+    agent: AgentNamespace
+    beta: BetaClient
+
     def __init__(
         self,
         api_key: Optional[str],
@@ -2654,6 +2657,9 @@ class Exa:
 
 
 class AsyncExa(Exa):
+    agent: AsyncAgentNamespace  # type: ignore[assignment]
+    beta: AsyncBetaClient  # type: ignore[assignment]
+
     def __init__(self, api_key: str, api_base: str = "https://api.exa.ai"):
         super().__init__(api_key, api_base)
         # Override the synchronous ResearchClient with its async counterpart.

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -9,7 +9,11 @@ from exa_py import AsyncExa, Exa
 from exa_py.agent import (
     AGENT_BETA_HEADER,
     AgentNamespace,
+    AgentRunEventsClient,
+    AgentRunsClient,
     AsyncAgentNamespace,
+    AsyncAgentRunEventsClient,
+    AsyncAgentRunsClient,
     AsyncBetaClient,
     BetaClient,
     ListAgentRunsResponse,
@@ -81,6 +85,9 @@ def test_exa_exposes_agent_run_under_agent_namespace():
     assert "betas" in signature(exa.beta.agent.runs.create).parameters
     assert "betas" not in signature(exa.agent.runs.events.list).parameters
     assert "betas" in signature(exa.beta.agent.runs.events.list).parameters
+    assert isinstance(exa.beta.agent, AgentNamespace)
+    assert isinstance(exa.beta.agent.runs, AgentRunsClient)
+    assert isinstance(exa.beta.agent.runs.events, AgentRunEventsClient)
 
 
 def test_async_exa_exposes_agent_run_under_agent_namespace():
@@ -93,6 +100,9 @@ def test_async_exa_exposes_agent_run_under_agent_namespace():
     assert "betas" in signature(exa.beta.agent.runs.create).parameters
     assert "betas" not in signature(exa.agent.runs.events.list).parameters
     assert "betas" in signature(exa.beta.agent.runs.events.list).parameters
+    assert isinstance(exa.beta.agent, AsyncAgentNamespace)
+    assert isinstance(exa.beta.agent.runs, AsyncAgentRunsClient)
+    assert isinstance(exa.beta.agent.runs.events, AsyncAgentRunEventsClient)
 
 
 def test_create_agent_run(run_client, mock_client):

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,3 +1,4 @@
+from inspect import signature
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -7,6 +8,8 @@ from pydantic import BaseModel, Field
 from exa_py import AsyncExa, Exa
 from exa_py.agent import (
     AGENT_BETA_HEADER,
+    AgentNamespace,
+    AsyncAgentNamespace,
     AsyncBetaClient,
     BetaClient,
     ListAgentRunsResponse,
@@ -22,7 +25,7 @@ def mock_client():
 
 @pytest.fixture
 def run_client(mock_client):
-    return BetaClient(mock_client).agent.runs
+    return AgentNamespace(mock_client).runs
 
 
 def _make_run(run_id: str = "agent_run_123") -> dict:
@@ -68,25 +71,34 @@ class _CompanyOutput(BaseModel):
     company_name: str = Field(alias="companyName")
 
 
-def test_exa_exposes_agent_run_under_beta_namespace():
+def test_exa_exposes_agent_run_under_agent_namespace():
     exa = Exa(api_key="test-api-key")
+    assert hasattr(exa.agent, "runs")
+    assert not hasattr(exa.agent, "run")
     assert hasattr(exa.beta.agent, "runs")
     assert not hasattr(exa.beta.agent, "run")
-    assert not hasattr(exa, "agent")
+    assert "betas" not in signature(exa.agent.runs.create).parameters
+    assert "betas" in signature(exa.beta.agent.runs.create).parameters
+    assert "betas" not in signature(exa.agent.runs.events.list).parameters
+    assert "betas" in signature(exa.beta.agent.runs.events.list).parameters
 
 
-def test_async_exa_exposes_agent_run_under_beta_namespace():
+def test_async_exa_exposes_agent_run_under_agent_namespace():
     exa = AsyncExa(api_key="test-api-key")
+    assert hasattr(exa.agent, "runs")
+    assert not hasattr(exa.agent, "run")
     assert hasattr(exa.beta.agent, "runs")
     assert not hasattr(exa.beta.agent, "run")
-    assert not hasattr(exa, "agent")
+    assert "betas" not in signature(exa.agent.runs.create).parameters
+    assert "betas" in signature(exa.beta.agent.runs.create).parameters
+    assert "betas" not in signature(exa.agent.runs.events.list).parameters
+    assert "betas" in signature(exa.beta.agent.runs.events.list).parameters
 
 
 def test_create_agent_run(run_client, mock_client):
     mock_client.request.return_value = _make_run()
 
     result = run_client.create(
-        betas=AGENT_BETAS,
         query="Find recent funding rounds.",
         system_prompt="Prefer primary sources.",
         input={"data": [{"company": "Example AI"}]},
@@ -110,20 +122,49 @@ def test_create_agent_run(run_client, mock_client):
         },
         method="POST",
         params=None,
+        headers={},
+    )
+
+
+def test_agent_run_does_not_accept_betas(run_client):
+    with pytest.raises(TypeError, match="betas"):
+        run_client.create(betas=AGENT_BETAS, query="Find recent funding rounds.")
+
+
+def test_beta_create_agent_run_sends_legacy_betas_as_header(mock_client):
+    mock_client.request.return_value = _make_run()
+    run_client = BetaClient(mock_client).agent.runs
+
+    run_client.create(betas=AGENT_BETAS, query="Find recent funding rounds.")
+
+    mock_client.request.assert_called_once_with(
+        "/agent/runs",
+        data={"query": "Find recent funding rounds."},
+        method="POST",
+        params=None,
         headers={"Exa-Beta": AGENT_BETA_HEADER},
     )
 
 
-def test_create_agent_run_requires_explicit_betas(run_client):
-    with pytest.raises(ValueError, match="betas"):
-        run_client.create(betas=[], query="Find recent funding rounds.")
+def test_beta_create_agent_run_omits_header_for_empty_betas(mock_client):
+    mock_client.request.return_value = _make_run()
+    run_client = BetaClient(mock_client).agent.runs
+
+    run_client.create(betas=[], query="Find recent funding rounds.")
+
+    mock_client.request.assert_called_once_with(
+        "/agent/runs",
+        data={"query": "Find recent funding rounds."},
+        method="POST",
+        params=None,
+        headers={},
+    )
 
 
 def test_create_agent_run_converts_pydantic_output_schema(run_client, mock_client):
     mock_client.request.return_value = _make_run()
 
     run_client.create(
-        betas=AGENT_BETAS,
         query="Find recent funding rounds.",
         output_schema=_CompanyOutput,
     )
@@ -137,7 +178,6 @@ def test_create_agent_run_accepts_contact_fields_in_output_schema(run_client, mo
     mock_client.request.return_value = _make_run()
 
     run_client.create(
-        betas=AGENT_BETAS,
         query="Find people at AI infrastructure companies and return work emails when available.",
         output_schema={
             "type": "object",
@@ -176,9 +216,9 @@ def test_get_cancel_and_delete_agent_run_paths(run_client, mock_client):
         {"id": "agent_run_123", "object": "agent_run.deleted", "deleted": True},
     ]
 
-    assert run_client.get("agent_run_123", betas=AGENT_BETAS).id == "agent_run_123"
-    assert run_client.cancel("agent_run_123", betas=AGENT_BETAS).status == "cancelled"
-    assert run_client.delete("agent_run_123", betas=AGENT_BETAS).deleted is True
+    assert run_client.get("agent_run_123").id == "agent_run_123"
+    assert run_client.cancel("agent_run_123").status == "cancelled"
+    assert run_client.delete("agent_run_123").deleted is True
 
     assert mock_client.request.call_args_list[0].args == ("/agent/runs/agent_run_123",)
     assert mock_client.request.call_args_list[0].kwargs["method"] == "GET"
@@ -198,7 +238,7 @@ def test_list_agent_runs(run_client, mock_client):
         "nextCursor": None,
     }
 
-    result = run_client.list(betas=AGENT_BETAS, limit=10)
+    result = run_client.list(limit=10)
 
     assert isinstance(result, ListAgentRunsResponse)
     assert result.data[0].id == "agent_run_1"
@@ -207,7 +247,7 @@ def test_list_agent_runs(run_client, mock_client):
         data=None,
         method="GET",
         params={"limit": "10"},
-        headers={"Exa-Beta": AGENT_BETA_HEADER},
+        headers={},
     )
 
 
@@ -233,13 +273,11 @@ def test_list_all_and_get_all_agent_runs(run_client, mock_client):
         },
     ]
 
-    assert [run.id for run in run_client.list_all(betas=AGENT_BETAS, limit=1)] == [
+    assert [run.id for run in run_client.list_all(limit=1)] == [
         "agent_run_1",
         "agent_run_2",
     ]
-    assert [run.id for run in run_client.get_all(betas=AGENT_BETAS, limit=1)] == [
-        "agent_run_3"
-    ]
+    assert [run.id for run in run_client.get_all(limit=1)] == ["agent_run_3"]
     assert mock_client.request.call_args_list[0].kwargs["params"] == {"limit": "1"}
     assert mock_client.request.call_args_list[1].kwargs["params"] == {
         "cursor": "cursor_2",
@@ -262,7 +300,7 @@ def test_agent_run_events(run_client, mock_client):
         "nextCursor": None,
     }
 
-    result = run_client.events.list("agent_run_123", betas=AGENT_BETAS, limit=20)
+    result = run_client.events.list("agent_run_123", limit=20)
 
     assert result.data[0].event == "agent_run.created"
     mock_client.request.assert_called_once_with(
@@ -270,15 +308,16 @@ def test_agent_run_events(run_client, mock_client):
         data=None,
         method="GET",
         params={"limit": "20"},
-        headers={"Exa-Beta": AGENT_BETA_HEADER},
+        headers={},
     )
 
 
-def test_cancel_and_delete_agent_run(run_client, mock_client):
+def test_beta_cancel_and_delete_agent_run_send_legacy_betas_as_header(mock_client):
     mock_client.request.side_effect = [
         {**_make_run(), "status": "cancelled", "stopReason": "cancelled"},
         {"id": "agent_run_123", "object": "agent_run.deleted", "deleted": True},
     ]
+    run_client = BetaClient(mock_client).agent.runs
 
     cancelled = run_client.cancel("agent_run_123", betas=AGENT_BETAS)
     deleted = run_client.delete("agent_run_123", betas=AGENT_BETAS)
@@ -298,6 +337,25 @@ def test_stream_create_sets_sse_headers(run_client, mock_client):
     response.iter_lines.return_value = []
     mock_client.request.return_value = response
 
+    events = run_client.create(query="Find companies.", stream=True)
+
+    assert list(events) == []
+    mock_client.request.assert_called_once_with(
+        "/agent/runs",
+        data={"query": "Find companies."},
+        method="POST",
+        params=None,
+        headers={"Accept": "text/event-stream"},
+    )
+    response.close.assert_called_once()
+
+
+def test_beta_stream_create_sets_sse_and_beta_headers(mock_client):
+    response = MagicMock()
+    response.iter_lines.return_value = []
+    mock_client.request.return_value = response
+    run_client = BetaClient(mock_client).agent.runs
+
     events = run_client.create(
         betas=AGENT_BETAS, query="Find companies.", stream=True
     )
@@ -308,7 +366,7 @@ def test_stream_create_sets_sse_headers(run_client, mock_client):
         data={"query": "Find companies."},
         method="POST",
         params=None,
-        headers={"Exa-Beta": AGENT_BETA_HEADER, "Accept": "text/event-stream"},
+        headers={"Accept": "text/event-stream", "Exa-Beta": AGENT_BETA_HEADER},
     )
     response.close.assert_called_once()
 
@@ -338,11 +396,35 @@ def test_poll_until_finished_returns_terminal_run(run_client, mock_client, monke
     monkeypatch.setattr("exa_py.agent.client.time.sleep", sleep)
 
     result = run_client.poll_until_finished(
-        "agent_run_123", betas=AGENT_BETAS, poll_interval=5, timeout_ms=1000
+        "agent_run_123", poll_interval=5, timeout_ms=1000
     )
 
     assert result.status == "completed"
     sleep.assert_called_once_with(0.005)
+
+
+def test_beta_poll_until_finished_sends_legacy_betas_as_header(
+    mock_client, monkeypatch
+):
+    mock_client.request.side_effect = [
+        {**_make_run(), "status": "running"},
+        {**_make_run(), "status": "completed"},
+    ]
+    sleep = MagicMock()
+    monkeypatch.setattr("exa_py.agent.client.time.sleep", sleep)
+    run_client = BetaClient(mock_client).agent.runs
+
+    result = run_client.poll_until_finished(
+        "agent_run_123", betas=AGENT_BETAS, poll_interval=5, timeout_ms=1000
+    )
+
+    assert result.status == "completed"
+    assert mock_client.request.call_args_list[0].kwargs["headers"] == {
+        "Exa-Beta": AGENT_BETA_HEADER
+    }
+    assert mock_client.request.call_args_list[1].kwargs["headers"] == {
+        "Exa-Beta": AGENT_BETA_HEADER
+    }
 
 
 def test_poll_until_finished_times_out(run_client, mock_client, monkeypatch):
@@ -353,12 +435,30 @@ def test_poll_until_finished_times_out(run_client, mock_client, monkeypatch):
 
     with pytest.raises(TimeoutError):
         run_client.poll_until_finished(
-            "agent_run_123", betas=AGENT_BETAS, poll_interval=5, timeout_ms=1
+            "agent_run_123", poll_interval=5, timeout_ms=1
         )
 
 
 @pytest.mark.asyncio
 async def test_async_agent_create():
+    client = MagicMock()
+    client.async_request = AsyncMock(return_value=_make_run())
+    run = AsyncAgentNamespace(client).runs
+
+    result = await run.create(query="Find recent funding rounds.", effort="auto")
+
+    assert result.id == "agent_run_123"
+    client.async_request.assert_awaited_once_with(
+        "/agent/runs",
+        data={"query": "Find recent funding rounds.", "effort": "auto"},
+        method="POST",
+        params=None,
+        headers={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_beta_agent_create_sends_legacy_betas_as_header():
     client = MagicMock()
     client.async_request = AsyncMock(return_value=_make_run())
     run = AsyncBetaClient(client).agent.runs
@@ -390,9 +490,9 @@ async def test_async_create_stream_parses_sse():
             ]
         )
     )
-    run = AsyncBetaClient(client).agent.runs
+    run = AsyncAgentNamespace(client).runs
 
-    stream = await run.create(betas=AGENT_BETAS, query="Find companies.", stream=True)
+    stream = await run.create(query="Find companies.", stream=True)
     events = [event async for event in stream]
 
     assert events[0].event == "agent_run.created"
@@ -403,7 +503,25 @@ async def test_async_create_stream_parses_sse():
         data={"query": "Find companies."},
         method="POST",
         params=None,
-        headers={"Exa-Beta": AGENT_BETA_HEADER, "Accept": "text/event-stream"},
+        headers={"Accept": "text/event-stream"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_beta_create_stream_sets_sse_and_beta_headers():
+    client = MagicMock()
+    client.async_request = AsyncMock(return_value=_MockAsyncSseResponse([]))
+    run = AsyncBetaClient(client).agent.runs
+
+    stream = await run.create(betas=AGENT_BETAS, query="Find companies.", stream=True)
+    assert [event async for event in stream] == []
+    assert client.async_request.return_value.closed is True
+    client.async_request.assert_awaited_once_with(
+        "/agent/runs",
+        data={"query": "Find companies."},
+        method="POST",
+        params=None,
+        headers={"Accept": "text/event-stream", "Exa-Beta": AGENT_BETA_HEADER},
     )
 
 


### PR DESCRIPTION
Moves Agent runs to the primary `exa.agent` namespace while keeping `exa.beta.agent` as a compatibility wrapper. Legacy `betas` values are optional and, when supplied, are sent as `Exa-Beta` from the beta namespace; no package version or lockfile changes are included. Validated with Agent unit tests, a local wheel smoke test, a Pyright compatibility script, and production API smoke calls.
