### PR TITLE
[codex] Bump exa-py version to 2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.13.2" # x-release-please-version
+version = "2.14.0" # x-release-please-version
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.13.2"
+version = "2.14.0"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.13.2",
+    version="2.14.0",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.13.2" # x-release-please-version
+version = "2.14.0" # x-release-please-version
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
## Summary

Bumps the exa-py package version to 2.14.0 after the agent API beta header requirement was removed from master.

Updated version metadata in:
- pyproject.toml
- setup.py
- uv.lock

## Validation

- `uv run pytest tests/unit` passed: 206 passed, 14 skipped
- `uv run pytest` was also attempted first, but the repo default pytest config targets `exa_py` and collected 0 tests
