### PR TITLE
feat(agent): remove beta header requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ for chunk in exa.stream_answer("Explain quantum computing"):
 
 ## Agent API 
 
+The Agent API is available without a beta header.
+
 ```python
 run = exa.agent.runs.create(
     query="Find engineering leaders at AI infrastructure companies that raised a Series A or B in the last 6 months.",


### PR DESCRIPTION
## Summary

Documents that the Agent API is available without a beta header.

This PR intentionally uses a Conventional Commit title so release-please can detect the Agent API beta-header removal as a minor release trigger and open the 2.14.0 release PR for exa-py.

## Validation

- Not run; README-only change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-py/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->