### PR TITLE
[codex] Add minimal Agent effort option

### DIFF
--- a/exa_py/agent/types.py
+++ b/exa_py/agent/types.py
@@ -12,7 +12,7 @@ AGENT_BETA_HEADER = "agent-2026-05-07"
 AgentRunStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
 AgentStopReason = Literal["schema_satisfied", "budget_reached", "error", "cancelled"]
 AgentConfidence = Literal["low", "medium", "high"]
-AgentEffort = Literal["low", "medium", "high", "xhigh", "auto"]
+AgentEffort = Literal["minimal", "low", "medium", "high", "xhigh", "auto"]
 
 
 class AgentInput(BaseModel):

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -113,7 +113,7 @@ def test_create_agent_run(run_client, mock_client):
         system_prompt="Prefer primary sources.",
         input={"data": [{"company": "Example AI"}]},
         output_schema={"type": "object"},
-        effort="high",
+        effort="minimal",
         metadata={"workflow": "funding-watch"},
     )
 
@@ -127,7 +127,7 @@ def test_create_agent_run(run_client, mock_client):
             "systemPrompt": "Prefer primary sources.",
             "input": {"data": [{"company": "Example AI"}]},
             "outputSchema": {"type": "object"},
-            "effort": "high",
+            "effort": "minimal",
             "metadata": {"workflow": "funding-watch"},
         },
         method="POST",


### PR DESCRIPTION
## Summary

Adds `minimal` to the Agent API `effort` type so Python SDK callers can pass the new effort option without client-side validation errors.

## Validation

- `uv run pytest tests/unit/test_agent.py`