### PR TITLE
feat(agent): add Exa Connect data_sources support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ run = exa.agent.runs.poll_until_finished(run.id)
 print(run.output.structured if run.output else None)
 ```
 
+Enable [Exa Connect](https://docs.exa.ai) data providers for a run with `data_sources` (up to 5):
+
+```python
+run = exa.agent.runs.create(
+    query="Summarize the latest financials for the top AI infrastructure companies.",
+    data_sources=[{"provider": "financial_datasets"}],
+)
+
+run = exa.agent.runs.poll_until_finished(run.id)
+print(run.usage.data_sources if run.usage else None)  # per-provider tool call counts
+```
+
 ## Async
 
 ```python

--- a/README.md
+++ b/README.md
@@ -154,18 +154,6 @@ run = exa.agent.runs.poll_until_finished(run.id)
 print(run.output.structured if run.output else None)
 ```
 
-Enable [Exa Connect](https://docs.exa.ai) data providers for a run with `data_sources` (up to 5):
-
-```python
-run = exa.agent.runs.create(
-    query="Summarize the latest financials for the top AI infrastructure companies.",
-    data_sources=[{"provider": "financial_datasets"}],
-)
-
-run = exa.agent.runs.poll_until_finished(run.id)
-print(run.usage.data_sources if run.usage else None)  # per-provider tool call counts
-```
-
 ## Async
 
 ```python

--- a/exa_py/agent/__init__.py
+++ b/exa_py/agent/__init__.py
@@ -17,6 +17,8 @@ from .async_client import (
 from .types import (
     AGENT_BETA_HEADER,
     AgentCostDollars,
+    AgentDataSource,
+    AgentDataSourceProvider,
     AgentEffort,
     AgentError,
     AgentEvent,
@@ -47,6 +49,8 @@ __all__ = [
     "AsyncAgentRunsClient",
     "AsyncAgentRunEventsClient",
     "AgentCostDollars",
+    "AgentDataSource",
+    "AgentDataSourceProvider",
     "AgentEffort",
     "AgentError",
     "AgentEvent",

--- a/exa_py/agent/async_client.py
+++ b/exa_py/agent/async_client.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from .async_base import AsyncAgentBaseClient
 from .client import _build_create_payload, _headers_for_betas
 from .types import (
+    AgentDataSource,
     AgentEvent,
     AgentEffort,
     AgentInput,
@@ -87,6 +88,7 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: Literal[False] = False,
     ) -> AgentRun: ...
 
@@ -101,6 +103,7 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: Literal[True] = True,
     ) -> AsyncGenerator[AgentEvent, None]: ...
 
@@ -114,6 +117,7 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: bool = False,
     ) -> Union[AgentRun, AsyncGenerator[AgentEvent, None]]:
         """Create an Agent run.
@@ -126,6 +130,7 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
             effort: Optional cost and reasoning effort preference. Defaults to auto.
             previous_run_id: Optional prior run ID to continue from.
             metadata: Optional metadata to attach to the run.
+            data_sources: Optional Exa Connect data providers to enable for the run.
             stream: Whether to stream server-sent Agent events instead of returning a run.
 
         Returns:
@@ -149,6 +154,7 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
             effort=effort,
             previous_run_id=previous_run_id,
             metadata=metadata,
+            data_sources=data_sources,
         )
 
         response = await self.request("", method="POST", data=payload, stream=stream)
@@ -378,6 +384,7 @@ class AsyncAgentBetaRunsClient(AsyncAgentRunsClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: Literal[False] = False,
     ) -> AgentRun: ...
 
@@ -393,6 +400,7 @@ class AsyncAgentBetaRunsClient(AsyncAgentRunsClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: Literal[True] = True,
     ) -> AsyncGenerator[AgentEvent, None]: ...
 
@@ -407,6 +415,7 @@ class AsyncAgentBetaRunsClient(AsyncAgentRunsClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: bool = False,
     ) -> Union[AgentRun, AsyncGenerator[AgentEvent, None]]:
         payload = _build_create_payload(
@@ -417,6 +426,7 @@ class AsyncAgentBetaRunsClient(AsyncAgentRunsClient):
             effort=effort,
             previous_run_id=previous_run_id,
             metadata=metadata,
+            data_sources=data_sources,
         )
         response = await self.request(
             "",

--- a/exa_py/agent/client.py
+++ b/exa_py/agent/client.py
@@ -22,6 +22,7 @@ from exa_py.utils import _convert_schema_input
 
 from .base import AgentBaseClient
 from .types import (
+    AgentDataSource,
     AgentEvent,
     AgentEffort,
     AgentInput,
@@ -61,6 +62,7 @@ def _build_create_payload(
     effort: Optional[AgentEffort] = None,
     previous_run_id: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
+    data_sources: Optional[list[AgentDataSource]] = None,
 ) -> Dict[str, Any]:
     schema = (
         _convert_schema_input(output_schema)
@@ -80,6 +82,7 @@ def _build_create_payload(
         effort=effort,
         previous_run_id=previous_run_id,
         metadata=metadata,
+        data_sources=data_sources,
     ).model_dump(by_alias=True, exclude_none=True)
 
 
@@ -139,6 +142,7 @@ class AgentRunsClient(AgentBaseClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: Literal[False] = False,
     ) -> AgentRun: ...
 
@@ -153,6 +157,7 @@ class AgentRunsClient(AgentBaseClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: Literal[True] = True,
     ) -> Generator[AgentEvent, None, None]: ...
 
@@ -166,6 +171,7 @@ class AgentRunsClient(AgentBaseClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: bool = False,
     ) -> Union[AgentRun, Generator[AgentEvent, None, None]]:
         """Create an Agent run.
@@ -178,6 +184,7 @@ class AgentRunsClient(AgentBaseClient):
             effort: Optional cost and reasoning effort preference. Defaults to auto.
             previous_run_id: Optional prior run ID to continue from.
             metadata: Optional metadata to attach to the run.
+            data_sources: Optional Exa Connect data providers to enable for the run.
             stream: Whether to stream server-sent Agent events instead of returning a run.
 
         Returns:
@@ -201,6 +208,7 @@ class AgentRunsClient(AgentBaseClient):
             effort=effort,
             previous_run_id=previous_run_id,
             metadata=metadata,
+            data_sources=data_sources,
         )
 
         response = self.request("", method="POST", data=payload, stream=stream)
@@ -423,6 +431,7 @@ class AgentBetaRunsClient(AgentRunsClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: Literal[False] = False,
     ) -> AgentRun: ...
 
@@ -438,6 +447,7 @@ class AgentBetaRunsClient(AgentRunsClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: Literal[True] = True,
     ) -> Generator[AgentEvent, None, None]: ...
 
@@ -452,6 +462,7 @@ class AgentBetaRunsClient(AgentRunsClient):
         effort: Optional[AgentEffort] = None,
         previous_run_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        data_sources: Optional[list[AgentDataSource]] = None,
         stream: bool = False,
     ) -> Union[AgentRun, Generator[AgentEvent, None, None]]:
         payload = _build_create_payload(
@@ -462,6 +473,7 @@ class AgentBetaRunsClient(AgentRunsClient):
             effort=effort,
             previous_run_id=previous_run_id,
             metadata=metadata,
+            data_sources=data_sources,
         )
         response = self.request(
             "",

--- a/exa_py/agent/types.py
+++ b/exa_py/agent/types.py
@@ -14,6 +14,25 @@ AgentStopReason = Literal["schema_satisfied", "budget_reached", "error", "cancel
 AgentConfidence = Literal["low", "medium", "high"]
 AgentEffort = Literal["low", "medium", "high", "xhigh", "auto"]
 
+AgentDataSourceProvider = Literal[
+    "fiber_ai",
+    "financial_datasets",
+    "similar_web",
+    "baselayer",
+    "affiliate",
+    "particle_news",
+    "jinko",
+]
+"""Identifier of an Exa Connect data provider."""
+
+
+class AgentDataSource(BaseModel):
+    """Exa Connect data source to enable for an Agent run."""
+
+    provider: AgentDataSourceProvider
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
 
 class AgentInput(BaseModel):
     data: Optional[List[Dict[str, Any]]] = None
@@ -51,6 +70,8 @@ class AgentUsage(BaseModel):
     searches: Optional[int] = None
     emails: Optional[int] = None
     phone_numbers: Optional[int] = Field(default=None, alias="phoneNumbers")
+    data_sources: Optional[Dict[str, int]] = Field(default=None, alias="dataSources")
+    """Per-provider tool call counts for Exa Connect data sources used during the run."""
 
     model_config = {"populate_by_name": True, "extra": "allow"}
 
@@ -61,6 +82,8 @@ class AgentCostDollars(BaseModel):
     search: Optional[float] = None
     emails: Optional[float] = None
     phone_numbers: Optional[float] = Field(default=None, alias="phoneNumbers")
+    data_sources: Optional[Dict[str, float]] = Field(default=None, alias="dataSources")
+    """Per-provider cost in dollars for Exa Connect data sources used during the run."""
 
     model_config = {"populate_by_name": True, "extra": "allow"}
 
@@ -136,5 +159,7 @@ class CreateAgentRunParams(BaseModel):
     effort: Optional[AgentEffort] = None
     previous_run_id: Optional[str] = Field(default=None, alias="previousRunId")
     metadata: Optional[Dict[str, Any]] = None
+    data_sources: Optional[List[AgentDataSource]] = Field(default=None, alias="dataSources")
+    """Exa Connect data providers to enable for the run (max 5)."""
 
     model_config = {"populate_by_name": True, "extra": "allow"}

--- a/exa_py/agent/types.py
+++ b/exa_py/agent/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -14,14 +14,17 @@ AgentStopReason = Literal["schema_satisfied", "budget_reached", "error", "cancel
 AgentConfidence = Literal["low", "medium", "high"]
 AgentEffort = Literal["low", "medium", "high", "xhigh", "auto"]
 
-AgentDataSourceProvider = Literal[
-    "fiber_ai",
-    "financial_datasets",
-    "similar_web",
-    "baselayer",
-    "affiliate",
-    "particle_news",
-    "jinko",
+AgentDataSourceProvider = Union[
+    Literal[
+        "fiber_ai",
+        "financial_datasets",
+        "similar_web",
+        "baselayer",
+        "affiliate",
+        "particle_news",
+        "jinko",
+    ],
+    str,
 ]
 """Identifier of an Exa Connect data provider."""
 

--- a/exa_py/agent/types.py
+++ b/exa_py/agent/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -14,23 +14,15 @@ AgentStopReason = Literal["schema_satisfied", "budget_reached", "error", "cancel
 AgentConfidence = Literal["low", "medium", "high"]
 AgentEffort = Literal["low", "medium", "high", "xhigh", "auto"]
 
-AgentDataSourceProvider = Union[
-    Literal[
-        "fiber_ai",
-        "financial_datasets",
-        "similar_web",
-        "baselayer",
-        "affiliate",
-        "particle_news",
-        "jinko",
-    ],
-    str,
-]
+AgentDataSourceProvider = str
 """Identifier of an Exa Connect data provider."""
 
 
 class AgentDataSource(BaseModel):
-    """Exa Connect data source to enable for an Agent run."""
+    """Exa Connect data source to enable for an Agent run.
+
+    See https://exa.ai/docs/reference/agent-api/connect/overview for available providers.
+    """
 
     provider: AgentDataSourceProvider
 
@@ -163,6 +155,6 @@ class CreateAgentRunParams(BaseModel):
     previous_run_id: Optional[str] = Field(default=None, alias="previousRunId")
     metadata: Optional[Dict[str, Any]] = None
     data_sources: Optional[List[AgentDataSource]] = Field(default=None, alias="dataSources")
-    """Exa Connect data providers to enable for the run (max 5)."""
+    """Exa Connect data providers to enable for the run."""
 
     model_config = {"populate_by_name": True, "extra": "allow"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-py"
-version = "2.14.0" # x-release-please-version
+version = "2.15.0" # x-release-please-version
 description = "Python SDK for Exa API."
 authors = ["Exa AI <hello@exa.ai>"]
 readme = "README.md"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "exa-py"
-version = "2.14.0"
+version = "2.15.0"
 description = "Python SDK for Exa API."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="exa_py",
-    version="2.14.0",
+    version="2.15.0",
     description="Python SDK for Exa API.",
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from exa_py import AsyncExa, Exa
 from exa_py.agent import (
     AGENT_BETA_HEADER,
+    AgentDataSource,
     AgentNamespace,
     AgentRunEventsClient,
     AgentRunsClient,
@@ -134,6 +135,44 @@ def test_create_agent_run(run_client, mock_client):
         params=None,
         headers={},
     )
+
+
+def test_create_agent_run_serializes_data_sources(run_client, mock_client):
+    mock_client.request.return_value = _make_run()
+
+    run_client.create(
+        query="Find recent funding rounds.",
+        data_sources=[
+            AgentDataSource(provider="financial_datasets"),
+            {"provider": "custom_provider"},
+        ],
+    )
+
+    payload = mock_client.request.call_args.kwargs["data"]
+    assert payload["dataSources"] == [
+        {"provider": "financial_datasets"},
+        {"provider": "custom_provider"},
+    ]
+
+
+def test_create_agent_run_omits_data_sources_when_not_provided(run_client, mock_client):
+    mock_client.request.return_value = _make_run()
+
+    run_client.create(query="Find recent funding rounds.")
+
+    assert "dataSources" not in mock_client.request.call_args.kwargs["data"]
+
+
+def test_agent_run_parses_data_source_usage_and_cost(run_client, mock_client):
+    run = _make_run()
+    run["usage"]["dataSources"] = {"financial_datasets": 3}
+    run["costDollars"]["dataSources"] = {"financial_datasets": 0.05}
+    mock_client.request.return_value = run
+
+    result = run_client.create(query="Find recent funding rounds.")
+
+    assert result.usage.data_sources == {"financial_datasets": 3}
+    assert result.cost_dollars.data_sources == {"financial_datasets": 0.05}
 
 
 def test_agent_run_does_not_accept_betas(run_client):
@@ -465,6 +504,21 @@ async def test_async_agent_create():
         params=None,
         headers={},
     )
+
+
+@pytest.mark.asyncio
+async def test_async_agent_create_serializes_data_sources():
+    client = MagicMock()
+    client.async_request = AsyncMock(return_value=_make_run())
+    run = AsyncAgentNamespace(client).runs
+
+    await run.create(
+        query="Find recent funding rounds.",
+        data_sources=[AgentDataSource(provider="similar_web")],
+    )
+
+    payload = client.async_request.await_args.kwargs["data"]
+    assert payload["dataSources"] == [{"provider": "similar_web"}]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -208,7 +208,7 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "2.14.0" # x-release-please-version
+version = "2.15.0" # x-release-please-version
 source = { editable = "." }
 dependencies = [
     { name = "httpcore" },


### PR DESCRIPTION
Adds Exa Connect `data_sources` support to the Agent API: a new `AgentDataSource` model and `AgentDataSourceProvider` type, threaded through the `data_sources` parameter on all create methods (sync/async, standard/beta) and serialized as `dataSources`. Adds per-provider parsing of `data_sources` on `AgentUsage` and `AgentCostDollars` from run responses. Includes unit tests covering serialization (sync + async) and usage/cost parsing, plus a README example. Bumps the package version to 2.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)