### PR TITLE
fix: clear errors when Exa API returns HTML / non-JSON

### DIFF
--- a/exa_py/api.py
+++ b/exa_py/api.py
@@ -53,6 +53,27 @@ is_beta = os.getenv("IS_BETA") == "True"
 DEFAULT_MAX_CHARACTERS = 10_000
 
 
+def _parse_api_json_response(
+    res: Union[requests.Response, httpx.Response],
+) -> Any:
+    """Decode JSON from an Exa API response.
+
+    Cloudflare / gateway errors often return HTML (``<!DOCTYPE …``). Calling
+    ``Response.json()`` then raises an opaque ``JSONDecodeError``. Surface a
+    ``ValueError`` that includes the HTTP status and a short body snippet so
+    callers can diagnose the failure (mirrors the exa-js non-JSON hardening).
+    """
+    try:
+        return res.json()
+    except (ValueError, json.JSONDecodeError) as exc:
+        text = getattr(res, "text", "") or ""
+        snippet = " ".join(text.split())[:200] or "<empty body>"
+        status = getattr(res, "status_code", "?")
+        raise ValueError(
+            f"Exa API returned a non-JSON response (status {status}): {snippet}"
+        ) from exc
+
+
 def _convert_contents_summary_schema(options: Dict[str, Any]) -> None:
     contents = options.get("contents")
     if not isinstance(contents, dict):
@@ -1562,7 +1583,7 @@ class Exa:
             raise ValueError(
                 f"Request failed with status code {res.status_code}: {res.text}"
             )
-        return res.json()
+        return _parse_api_json_response(res)
 
     def search(
         self,
@@ -2772,7 +2793,7 @@ class AsyncExa(Exa):
             raise ValueError(
                 f"Request failed with status code {res.status_code}: {res.text}"
             )
-        return res.json()
+        return _parse_api_json_response(res)
 
     async def search(
         self,

--- a/tests/unit/test_search_api.py
+++ b/tests/unit/test_search_api.py
@@ -81,6 +81,53 @@ def test_answerresponse_accepts_dict():
     assert isinstance(resp.answer, dict) and resp.answer["foo"] == "bar"
 
 
+def test_parse_api_json_response_accepts_valid_json():
+    class _Ok:
+        status_code = 200
+        text = '{"ok": true}'
+
+        def json(self):
+            return {"ok": True}
+
+    assert exa_api._parse_api_json_response(_Ok()) == {"ok": True}
+
+
+def test_parse_api_json_response_rejects_html_body():
+    import json
+
+    class _Html:
+        status_code = 502
+        text = "<!DOCTYPE html><html><body>Bad Gateway</body></html>"
+
+        def json(self):
+            raise json.JSONDecodeError("Expecting value", self.text, 0)
+
+    with pytest.raises(ValueError, match="non-JSON response \\(status 502\\).*DOCTYPE"):
+        exa_api._parse_api_json_response(_Html())
+
+
+def test_request_surfaces_non_json_success_body(monkeypatch):
+    """Even HTTP 200 HTML (e.g. Cloudflare) must not raise opaque JSONDecodeError."""
+    import json
+
+    exa = Exa(API_KEY)
+
+    class _Html200:
+        status_code = 200
+        text = "<!DOCTYPE html><html><title>Oops</title></html>"
+
+        def json(self):
+            raise json.JSONDecodeError("Expecting value", self.text, 0)
+
+    monkeypatch.setattr(
+        exa_api.requests,
+        "post",
+        lambda *args, **kwargs: _Html200(),
+    )
+
+    with pytest.raises(ValueError, match="non-JSON response \\(status 200\\)"):
+        exa.request("/search", {"query": "test"})
+
 def test_search_accepts_user_location_offline():
     """Test that search method accepts user_location parameter without error."""
     exa = Exa(API_KEY)


### PR DESCRIPTION
## Problem

When Cloudflare / a gateway returns HTML instead of JSON, `Exa.request` / `AsyncExa.async_request` call `Response.json()` and raise an opaque `JSONDecodeError` — production agents can't tell status vs body.

Same failure class as exa-js #139 / #92.

Fixes #

## Fix

- Add `_parse_api_json_response` helper
- Use it for sync + async non-streaming responses
- Raise `ValueError` with HTTP status + short body snippet

## Verify

```bash
python -m pytest tests/unit/test_search_api.py -k \"non_json or parse_api\" -q
```