### PR TITLE
fix: accept list structured monitor run content (#208)

### DIFF
--- a/exa_py/monitors/types.py
+++ b/exa_py/monitors/types.py
@@ -192,7 +192,7 @@ class GroundingEntry(BaseModel):
 
 class SearchMonitorRunOutput(BaseModel):
     results: Optional[List[Dict[str, Any]]] = None
-    content: Optional[Union[str, Dict[str, Any]]] = None
+    content: Optional[Union[str, Dict[str, Any], List[Any]]] = None
     grounding: Optional[List[GroundingEntry]] = None
 
     model_config = {"populate_by_name": True}

--- a/tests/unit/test_search_monitors.py
+++ b/tests/unit/test_search_monitors.py
@@ -205,7 +205,7 @@ class TestTriggerResponse:
 
 class TestSearchMonitorRunOutputContent:
     """Runs configured with an outputSchema return ``output.content`` as a
-    structured object, so the field must accept both ``str`` and ``dict``."""
+    structured object/list, so the field must accept ``str``, ``dict``, and ``list``."""
 
     def _make_run_with_content(self, content) -> dict:
         run = _make_run("run_1")
@@ -225,6 +225,17 @@ class TestSearchMonitorRunOutputContent:
         assert run.output is not None
         assert run.output.content == "plain text"
 
+    def test_get_run_with_structured_list_content(self, monitors_client, mock_client):
+        # Issue #208: schema output can be a list of objects; typing as str-only breaks list().
+        structured_list = [
+            {"title": "First hit", "url": "https://example.com/1"},
+            {"title": "Second hit", "url": "https://example.com/2"},
+        ]
+        mock_client.request.return_value = self._make_run_with_content(structured_list)
+        run = monitors_client.runs.get("sm_123", "run_1")
+        assert run.output is not None
+        assert run.output.content == structured_list
+
     def test_list_runs_with_structured_content(self, monitors_client, mock_client):
         structured = {"summary": "AI breakthroughs"}
         mock_client.request.return_value = {
@@ -234,3 +245,13 @@ class TestSearchMonitorRunOutputContent:
         }
         runs = monitors_client.runs.list("sm_123")
         assert runs.data[0].output.content == structured
+
+    def test_list_runs_with_structured_list_content(self, monitors_client, mock_client):
+        structured_list = [{"id": "anthropic", "score": 0.99}]
+        mock_client.request.return_value = {
+            "data": [self._make_run_with_content(structured_list)],
+            "hasMore": False,
+            "nextCursor": None,
+        }
+        runs = monitors_client.runs.list("sm_123")
+        assert runs.data[0].output.content == structured_list


### PR DESCRIPTION
## Problem

`SearchMonitorRunOutput.content` was typed as `str | dict`. When a monitor uses a structured `outputSchema` that returns a **list** of objects, `SearchMonitorRunsClient.list` / `get` fail pydantic validation.

Fixes #208

## Note on existing PR

[#209](https://github.com/exa-labs/exa-py/pull/209) covers the same issue but is **merge-conflicting** and also bumps package version. This PR is a minimal rebase on current `master`: type union + tests only (no version bump). Happy to close this if #209 is preferred after a rebase.

## Fix

```python
content: Optional[Union[str, Dict[str, Any], List[Any]]] = None
```

## Verify

```bash
python -m pytest tests/unit/test_search_monitors.py::TestSearchMonitorRunOutputContent -q
```