### PR TITLE
feat: support agent max duration for max effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ exa = Exa()
 run = exa.beta.agent.runs.create(
     query="Find all companies building browser automation tools in the United States.",
     effort="max",
-    budget={"maxCostDollars": 10},
+    budget={"maxCostDollars": 10, "maxDurationSeconds": 600},
     betas=[AGENT_MAX_EFFORT_BETA],
 )
 ```

--- a/exa_py/agent/async_client.py
+++ b/exa_py/agent/async_client.py
@@ -141,8 +141,9 @@ class AsyncAgentRunsClient(AsyncAgentBaseClient):
             input: Optional structured input data for the Agent.
             output_schema: Optional JSON schema or Pydantic model for structured output.
             effort: Optional cost and reasoning effort preference. Defaults to auto.
-            budget: Optional per-run spend ceiling for `auto` and `max`; the API
-                validates this field and applies defaults when omitted.
+            budget: Optional per-run budget ceilings (cost for `auto` and `max`,
+                duration for `max` only); the API validates this field and
+                applies defaults when omitted.
             previous_run_id: Optional prior run ID to continue from.
             metadata: Optional metadata to attach to the run.
             data_sources: Optional Exa Connect data providers to enable for the run.

--- a/exa_py/agent/client.py
+++ b/exa_py/agent/client.py
@@ -194,8 +194,9 @@ class AgentRunsClient(AgentBaseClient):
             input: Optional structured input data for the Agent.
             output_schema: Optional JSON schema or Pydantic model for structured output.
             effort: Optional cost and reasoning effort preference. Defaults to auto.
-            budget: Optional per-run spend ceiling for `auto` and `max`; the API
-                validates this field and applies defaults when omitted.
+            budget: Optional per-run budget ceilings (cost for `auto` and `max`,
+                duration for `max` only); the API validates this field and
+                applies defaults when omitted.
             previous_run_id: Optional prior run ID to continue from.
             metadata: Optional metadata to attach to the run.
             data_sources: Optional Exa Connect data providers to enable for the run.
@@ -426,8 +427,9 @@ class AgentRunsClient(AgentBaseClient):
             input: Optional structured input data for the Agent.
             output_schema: Optional JSON schema or Pydantic model for structured output.
             effort: Optional cost and reasoning effort preference. Defaults to auto.
-            budget: Optional per-run spend ceiling for `auto` and `max`; the API
-                validates this field and applies defaults when omitted.
+            budget: Optional per-run budget ceilings (cost for `auto` and `max`,
+                duration for `max` only); the API validates this field and
+                applies defaults when omitted.
             previous_run_id: Optional prior run ID to continue from.
             metadata: Optional metadata to attach to the run.
             data_sources: Optional Exa Connect data providers to enable for the run.

--- a/exa_py/agent/types.py
+++ b/exa_py/agent/types.py
@@ -11,7 +11,14 @@ AGENT_BETA_HEADER = "agent-2026-05-07"
 AGENT_MAX_EFFORT_BETA = "agent-max-effort-2026-07-27"
 
 AgentRunStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
-AgentStopReason = Literal["schema_satisfied", "budget_reached", "error", "cancelled"]
+AgentStopReason = Literal[
+    "schema_satisfied",
+    "budget_reached",
+    "time_limit_reached",
+    "timeout_partial",
+    "error",
+    "cancelled",
+]
 AgentConfidence = Literal["low", "medium", "high"]
 AgentEffort = Literal["minimal", "low", "medium", "high", "xhigh", "auto", "max"]
 
@@ -97,7 +104,8 @@ class AgentError(BaseModel):
 
 
 class AgentBudget(BaseModel):
-    """Per-run spend ceiling for the metered `auto` and `max` efforts."""
+    """Per-run budget ceilings for the metered efforts: the cost ceiling applies
+    to `auto` and `max`; the duration ceiling applies to `max` only."""
 
     max_cost_dollars: Optional[float] = Field(
         default=None,
@@ -106,6 +114,16 @@ class AgentBudget(BaseModel):
             "Maximum spend for the run in US dollars. Only accepted by the API "
             "for `auto` and `max`; the server validates the allowed range and "
             "applies defaults when omitted."
+        ),
+    )
+
+    max_duration_seconds: Optional[int] = Field(
+        default=None,
+        alias="maxDurationSeconds",
+        description=(
+            "Best-effort maximum duration for the run in seconds. Only accepted "
+            "by the API for `max`; the server validates the allowed range and "
+            "may take a little additional time to finish gracefully."
         ),
     )
 

--- a/exa_py/agent/types.py
+++ b/exa_py/agent/types.py
@@ -123,7 +123,10 @@ class AgentBudget(BaseModel):
         description=(
             "Best-effort maximum duration for the run in seconds. Only accepted "
             "by the API for `max`; the server validates the allowed range and "
-            "may take a little additional time to finish gracefully."
+            "may take a little additional time to finish gracefully. Runs that "
+            "hit the limit stop with `stop_reason` `time_limit_reached` (or "
+            "`timeout_partial` if the graceful wrap-up could not finish) and "
+            "return partial output."
         ),
     )
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -206,7 +206,7 @@ def test_beta_create_agent_run_sends_max_effort_and_budget(mock_client):
         betas=[AGENT_MAX_EFFORT_BETA],
         query="Find recent funding rounds.",
         effort="max",
-        budget={"maxCostDollars": 10},
+        budget={"maxCostDollars": 10, "maxDurationSeconds": 600},
     )
 
     mock_client.request.assert_called_once_with(
@@ -214,7 +214,7 @@ def test_beta_create_agent_run_sends_max_effort_and_budget(mock_client):
         data={
             "query": "Find recent funding rounds.",
             "effort": "max",
-            "budget": {"maxCostDollars": 10},
+            "budget": {"maxCostDollars": 10, "maxDurationSeconds": 600},
         },
         method="POST",
         params=None,


### PR DESCRIPTION
Adds support for the agent max duration budget:

- `AgentBudget` gains an optional `max_duration_seconds` field (wire name `maxDurationSeconds`), a best-effort maximum run duration in seconds. Only accepted by the API for `max` effort; the server validates the allowed range and may take a little additional time to finish gracefully.
- `AgentStopReason` gains `time_limit_reached` and `timeout_partial`, so runs stopped by the time limit parse cleanly.
- Budget docstrings updated to cover both cost and duration ceilings.

Unit tests updated to exercise the new budget field end-to-end (39 passed). Verified live against production: range/type/effort-gating validation, budget echo and persistence, async client parity, and a real run hitting the soft deadline with `stop_reason=time_limit_reached`.