### PR TITLE
Add graceful Agent run stopping

### DIFF
--- a/exa_py/agent/async_client.py
+++ b/exa_py/agent/async_client.py
@@ -29,6 +29,7 @@ from .client import (
     _headers_for_betas,
 )
 from .types import (
+    AGENT_MAX_EFFORT_BETA,
     AgentDataSource,
     AgentBudget,
     AgentEvent,
@@ -569,6 +570,18 @@ class AsyncAgentBetaRunsClient(AsyncAgentRunsClient):
     ) -> AgentRun:
         response = await self.request(
             f"/{run_id}/cancel", method="POST", headers=_headers_for_betas(betas)
+        )
+        return AgentRun.model_validate(response)
+
+    async def stop(
+        self, run_id: str, *, betas: Optional[Sequence[str]] = None
+    ) -> AgentRun:
+        response = await self.request(
+            f"/{run_id}/stop",
+            method="POST",
+            headers=_headers_for_betas(
+                betas if betas is not None else [AGENT_MAX_EFFORT_BETA]
+            ),
         )
         return AgentRun.model_validate(response)
 

--- a/exa_py/agent/client.py
+++ b/exa_py/agent/client.py
@@ -24,6 +24,7 @@ from .base import AgentBaseClient
 from .betas import headers_for_betas as _headers_for_betas
 from .monitors.client import AgentMonitorsClient
 from .types import (
+    AGENT_MAX_EFFORT_BETA,
     AgentDataSource,
     AgentEvent,
     AgentEffort,
@@ -607,6 +608,16 @@ class AgentBetaRunsClient(AgentRunsClient):
     def cancel(self, run_id: str, *, betas: Optional[Sequence[str]] = None) -> AgentRun:
         response = self.request(
             f"/{run_id}/cancel", method="POST", headers=_headers_for_betas(betas)
+        )
+        return AgentRun.model_validate(response)
+
+    def stop(self, run_id: str, *, betas: Optional[Sequence[str]] = None) -> AgentRun:
+        response = self.request(
+            f"/{run_id}/stop",
+            method="POST",
+            headers=_headers_for_betas(
+                betas if betas is not None else [AGENT_MAX_EFFORT_BETA]
+            ),
         )
         return AgentRun.model_validate(response)
 

--- a/exa_py/agent/types.py
+++ b/exa_py/agent/types.py
@@ -11,7 +11,9 @@ AGENT_BETA_HEADER = "agent-2026-05-07"
 AGENT_MAX_EFFORT_BETA = "agent-max-effort-2026-07-27"
 
 AgentRunStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
-AgentStopReason = Literal["schema_satisfied", "budget_reached", "error", "cancelled"]
+AgentStopReason = Literal[
+    "schema_satisfied", "budget_reached", "stopped", "error", "cancelled"
+]
 AgentConfidence = Literal["low", "medium", "high"]
 AgentEffort = Literal["minimal", "low", "medium", "high", "xhigh", "auto", "max"]
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -85,6 +85,8 @@ def test_exa_exposes_agent_run_under_agent_namespace():
     assert not hasattr(exa.agent, "run")
     assert hasattr(exa.beta.agent, "runs")
     assert not hasattr(exa.beta.agent, "run")
+    assert not hasattr(exa.agent.runs, "stop")
+    assert hasattr(exa.beta.agent.runs, "stop")
     assert "betas" not in signature(exa.agent.runs.create).parameters
     assert "betas" in signature(exa.beta.agent.runs.create).parameters
     assert "betas" not in signature(exa.agent.runs.events.list).parameters
@@ -100,6 +102,8 @@ def test_async_exa_exposes_agent_run_under_agent_namespace():
     assert not hasattr(exa.agent, "run")
     assert hasattr(exa.beta.agent, "runs")
     assert not hasattr(exa.beta.agent, "run")
+    assert not hasattr(exa.agent.runs, "stop")
+    assert hasattr(exa.beta.agent.runs, "stop")
     assert "betas" not in signature(exa.agent.runs.create).parameters
     assert "betas" in signature(exa.beta.agent.runs.create).parameters
     assert "betas" not in signature(exa.agent.runs.events.list).parameters
@@ -406,6 +410,22 @@ def test_beta_cancel_and_delete_agent_run_send_legacy_betas_as_header(mock_clien
     assert mock_client.request.call_args_list[1].kwargs["headers"] == {
         "Exa-Beta": AGENT_BETA_HEADER
     }
+
+
+def test_beta_stop_agent_run_uses_max_effort_beta_by_default(mock_client):
+    mock_client.request.return_value = {**_make_run(), "stopReason": "stopped"}
+    run_client = BetaClient(mock_client).agent.runs
+
+    stopped = run_client.stop("agent_run_123")
+
+    assert stopped.stop_reason == "stopped"
+    mock_client.request.assert_called_once_with(
+        "/agent/runs/agent_run_123/stop",
+        data=None,
+        method="POST",
+        params=None,
+        headers={"Exa-Beta": AGENT_MAX_EFFORT_BETA},
+    )
 
 
 def test_stream_create_sets_sse_headers(run_client, mock_client):


### PR DESCRIPTION
Adds `beta.agent.runs.stop` for max-effort runs and supports the `stopped` stop reason.