### PR TITLE
feat(helpers): get_contents tool helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ for chunk in exa.stream_answer("Explain quantum computing"):
     print(chunk, end="", flush=True)
 ```
 
-## Web Search tools
+## Web Search and Contents tools
 
 Use Exa as a `web_search` tool in an OpenAI or Anthropic loop. Call `web_search()` with no arguments to get Exa's recommended settings for agentic search (`type="auto"` and `contents={"highlights": True}`).
 
@@ -167,6 +167,19 @@ response = client.messages.create(
     tools=[
         exa.anthropic.web_search(name="exa_web_search"),
         {"type": "web_search_20250305", "name": "web_search", "max_uses": 5},
+    ],
+)
+```
+
+`get_contents` is available in the same namespaces and lets the model read pages it already has URLs for. It takes a list of URLs and accepts every `Exa.get_contents` option:
+
+```python
+completion = openai_client.chat.completions.create(
+    model="gpt-5.6",
+    messages=messages,
+    tools=[
+        exa.openai.web_search(),
+        exa.openai.get_contents(summary=True, livecrawl="preferred"),
     ],
 )
 ```

--- a/exa_py/tools.py
+++ b/exa_py/tools.py
@@ -14,6 +14,11 @@ DEFAULT_WEB_SEARCH_DESCRIPTION = (
     "Describe the ideal page rather than listing keywords."
 )
 
+DEFAULT_GET_CONTENTS_DESCRIPTION = (
+    "Read the full contents of web pages you already have URLs for, such as "
+    "pages returned by a search or mentioned by the user."
+)
+
 
 class _WebSearchInput(BaseModel):
     query: str = Field(
@@ -24,13 +29,22 @@ class _WebSearchInput(BaseModel):
     )
 
 
+class _GetContentsInput(BaseModel):
+    urls: list[str] = Field(
+        description=(
+            "Absolute URLs of the pages to read, including the scheme. Pass "
+            "several URLs to read them in a single call."
+        )
+    )
+
+
 def _value(result: Any, name: str, default: Any = None) -> Any:
     if isinstance(result, Mapping):
         return result.get(name, default)
     return getattr(result, name, default)
 
 
-def _format_response(response: Any) -> str:
+def _format_results(response: Any, empty_message: str) -> str:
     results = _value(response, "results", []) or []
     formatted = []
     for result in results:
@@ -40,14 +54,25 @@ def _format_response(response: Any) -> str:
             f"Published: {_value(result, 'published_date') or 'N/A'}",
             f"Author: {_value(result, 'author') or 'N/A'}",
         ]
+        summary = _value(result, "summary")
         highlights = _value(result, "highlights")
         text = _value(result, "text")
+        if summary:
+            lines.append(f"Summary: {summary}")
         if highlights:
             lines.append(f"Highlights:\n{chr(10).join(highlights)}")
         elif text:
             lines.append(f"Text: {text}")
         formatted.append("\n".join(lines))
-    return "\n\n---\n\n".join(formatted) or "No search results found."
+    return "\n\n---\n\n".join(formatted) or empty_message
+
+
+def _format_response(response: Any) -> str:
+    return _format_results(response, "No search results found.")
+
+
+def _format_contents_response(response: Any) -> str:
+    return _format_results(response, "No contents found.")
 
 
 def _schema(model: type[BaseModel]) -> dict[str, Any]:
@@ -66,6 +91,7 @@ class _ToolSpec:
         input_model: type[BaseModel],
         execute: Callable[[dict[str, Any]], Any],
         registry: "_ToolRegistry",
+        formatter: Callable[[Any], str] = _format_response,
     ):
         self.name = name
         self.description = description
@@ -73,6 +99,7 @@ class _ToolSpec:
         self.input_schema = _schema(input_model)
         self.json_schema = self.input_schema
         self._execute = execute
+        self._formatter = formatter
         self.definition = {
             "name": name,
             "description": description,
@@ -116,7 +143,7 @@ class _ToolSpec:
         return self.input_model.model_validate(args).model_dump()
 
     def format(self, result: Any) -> str:
-        return _format_response(result)
+        return self._formatter(result)
 
     async def async_run(self, args: Any) -> str:
         """Execute a synchronous tool through an awaitable compatibility method.
@@ -139,6 +166,7 @@ class _AsyncToolSpec(_ToolSpec):
         input_model: type[BaseModel],
         execute: Callable[[dict[str, Any]], Awaitable[Any]],
         registry: "_ToolRegistry",
+        formatter: Callable[[Any], str] = _format_response,
     ):
         super().__init__(
             name=name,
@@ -146,6 +174,7 @@ class _AsyncToolSpec(_ToolSpec):
             input_model=input_model,
             execute=execute,
             registry=registry,
+            formatter=formatter,
         )
 
     async def execute(self, args: Any) -> Any:
@@ -321,6 +350,26 @@ class ToolNamespace:
         """
         return _create_web_search(self._exa, self._registry, False, kwargs)
 
+    def get_contents(self, **kwargs: Any) -> _ToolSpec:
+        """Create a provider-neutral Exa contents tool.
+
+        Inherits ``Exa.get_contents`` defaults, which return page text capped at
+        10,000 characters when no content option is configured.
+
+        Args:
+            **kwargs: Optional contents options passed through to
+                ``Exa.get_contents`` (e.g. ``text``, ``summary``, ``livecrawl``).
+                ``name`` (default ``"get_contents"``) and ``description``
+                override the advertised tool name and description instead.
+
+        Returns:
+            A registered executable tool specification.
+
+        Examples:
+            ``exa.tools.get_contents()`` or ``exa.tools.get_contents(summary=True)``.
+        """
+        return _create_get_contents(self._exa, self._registry, False, kwargs)
+
 
 class OpenAINamespace(ToolNamespace):
     def web_search(self, **kwargs: Any) -> OpenAITool:
@@ -333,6 +382,20 @@ class OpenAINamespace(ToolNamespace):
         """
         spec = super().web_search(**kwargs)
         return _openai_tool(spec)
+
+    def get_contents(self, **kwargs: Any) -> OpenAITool:
+        """Create an OpenAI Chat Completions contents tool.
+
+        Args:
+            **kwargs: Contents options plus ``name`` and ``description``.
+
+        Returns:
+            A wire-safe OpenAI tool with an executable handle.
+
+        Examples:
+            ``tools=[exa.openai.get_contents()]``.
+        """
+        return _openai_tool(super().get_contents(**kwargs))
 
     def handle_tool_calls(
         self, message: Any, tools: Optional[list[_ToolSpec]] = None
@@ -423,6 +486,20 @@ class OpenAIResponsesNamespace(ToolNamespace):
     def web_search(self, **kwargs: Any) -> OpenAIResponsesTool:
         return _responses_tool(super().web_search(**kwargs))
 
+    def get_contents(self, **kwargs: Any) -> OpenAIResponsesTool:
+        """Create an OpenAI Responses contents tool.
+
+        Args:
+            **kwargs: Contents options plus ``name`` and ``description``.
+
+        Returns:
+            A wire-safe OpenAI Responses tool with an executable handle.
+
+        Examples:
+            ``tools=[exa.openai.responses.get_contents()]``.
+        """
+        return _responses_tool(super().get_contents(**kwargs))
+
     def handle_tool_calls(
         self, response_or_items: Any, tools: Optional[list[_ToolSpec]] = None
     ) -> list[dict[str, str]]:
@@ -500,6 +577,20 @@ class OpenAIResponsesNamespace(ToolNamespace):
 class AnthropicNamespace(ToolNamespace):
     def web_search(self, **kwargs: Any) -> Any:
         return _anthropic_tool(super().web_search(**kwargs), False)
+
+    def get_contents(self, **kwargs: Any) -> Any:
+        """Create an Anthropic Messages contents tool.
+
+        Args:
+            **kwargs: Contents options plus ``name`` and ``description``.
+
+        Returns:
+            A wire-safe Anthropic tool with an executable handle.
+
+        Examples:
+            ``tools=[exa.anthropic.get_contents()]``.
+        """
+        return _anthropic_tool(super().get_contents(**kwargs), False)
 
     def handle_tool_use(
         self, message: Any, tools: Optional[list[_ToolSpec]] = None
@@ -581,6 +672,20 @@ class AsyncToolNamespace(ToolNamespace):
         """
         return _create_web_search(self._exa, self._registry, True, kwargs)
 
+    def get_contents(self, **kwargs: Any) -> _AsyncToolSpec:
+        """Create an asynchronous provider-neutral contents tool.
+
+        Args:
+            **kwargs: Contents options and tool options.
+
+        Returns:
+            An asynchronous executable tool specification.
+
+        Examples:
+            ``tool = async_exa.tools.get_contents()``.
+        """
+        return _create_get_contents(self._exa, self._registry, True, kwargs)
+
 
 class AsyncOpenAINamespace(OpenAINamespace, AsyncToolNamespace):
     """OpenAI tool namespace for ``AsyncExa``."""
@@ -588,6 +693,12 @@ class AsyncOpenAINamespace(OpenAINamespace, AsyncToolNamespace):
     def web_search(self, **kwargs: Any) -> AsyncOpenAITool:
         return _openai_tool(
             _create_web_search(self._exa, self._registry, True, kwargs), asynchronous=True
+        )
+
+    def get_contents(self, **kwargs: Any) -> AsyncOpenAITool:
+        return _openai_tool(
+            _create_get_contents(self._exa, self._registry, True, kwargs),
+            asynchronous=True,
         )
 
     async def handle_tool_calls(
@@ -624,6 +735,12 @@ class AsyncOpenAIResponsesNamespace(OpenAIResponsesNamespace, AsyncToolNamespace
             asynchronous=True,
         )
 
+    def get_contents(self, **kwargs: Any) -> AsyncOpenAIResponsesTool:
+        return _responses_tool(
+            _create_get_contents(self._exa, self._registry, True, kwargs),
+            asynchronous=True,
+        )
+
     async def handle_tool_calls(
         self, response_or_items: Any, tools: Optional[list[_ToolSpec]] = None
     ) -> list[dict[str, str]]:
@@ -649,6 +766,11 @@ class AsyncAnthropicNamespace(AnthropicNamespace, AsyncToolNamespace):
     def web_search(self, **kwargs: Any) -> Any:
         return _anthropic_tool(
             _create_web_search(self._exa, self._registry, True, kwargs), True
+        )
+
+    def get_contents(self, **kwargs: Any) -> Any:
+        return _anthropic_tool(
+            _create_get_contents(self._exa, self._registry, True, kwargs), True
         )
 
     async def handle_tool_use(
@@ -707,6 +829,30 @@ def _create_web_search(
         registry=registry,
     )
     return spec
+
+
+def _create_get_contents(
+    exa: Any, registry: _ToolRegistry, asynchronous: bool, kwargs: dict[str, Any]
+) -> _ToolSpec:
+    config = dict(kwargs)
+    name = config.pop("name", "get_contents")
+    description = config.pop("description", DEFAULT_GET_CONTENTS_DESCRIPTION)
+
+    def execute(args: dict[str, Any]) -> Any:
+        return exa.get_contents(args["urls"], **config)
+
+    async def async_execute(args: dict[str, Any]) -> Any:
+        return await exa.get_contents(args["urls"], **config)
+
+    spec_class = _AsyncToolSpec if asynchronous else _ToolSpec
+    return spec_class(
+        name=name,
+        description=description,
+        input_model=_GetContentsInput,
+        execute=async_execute if asynchronous else execute,
+        registry=registry,
+        formatter=_format_contents_response,
+    )
 
 
 def _openai_tool(spec: _ToolSpec, asynchronous: bool = False) -> OpenAITool:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -19,6 +19,7 @@ def result(**kwargs):
         author=kwargs.get("author"),
         highlights=kwargs.get("highlights"),
         text=kwargs.get("text"),
+        summary=kwargs.get("summary"),
     )
 
 
@@ -362,3 +363,165 @@ async def test_async_tools_and_handlers():
         "tool_use_id": "v",
         "content": 'Error: unknown tool "missing"',
     }
+
+
+def test_contents_tool_is_wire_safe_and_takes_urls():
+    exa = Exa("test")
+    exa.get_contents = lambda urls, **kwargs: response(result(text="Page text"))
+    tool = exa.openai.get_contents()
+
+    assert list(tool) == ["type", "function"]
+    assert json.loads(json.dumps(tool)) == tool
+    assert tool["function"]["name"] == "get_contents"
+    assert tool["function"]["parameters"]["required"] == ["urls"]
+    assert set(tool["function"]["parameters"]["properties"]) == {"urls"}
+    assert tool["function"]["parameters"]["properties"]["urls"]["type"] == "array"
+    assert "$schema" not in tool["function"]["parameters"]
+    assert "run" not in json.dumps(tool)
+    assert "Text: Page text" in tool.run({"urls": ["https://example.com"]})
+
+
+def test_contents_passes_urls_and_options_through():
+    exa = Exa("test")
+    seen = {}
+
+    def get_contents(urls, **kwargs):
+        seen["urls"] = urls
+        seen["kwargs"] = kwargs
+        return response(result(summary="A summary"))
+
+    exa.get_contents = get_contents
+    tool = exa.tools.get_contents(
+        name="read_pages",
+        description="Read pages",
+        summary=True,
+        livecrawl="preferred",
+    )
+    output = tool.run({"urls": ["https://example.com", "https://exa.ai"]})
+
+    assert seen["urls"] == ["https://example.com", "https://exa.ai"]
+    assert seen["kwargs"] == {"summary": True, "livecrawl": "preferred"}
+    assert "Summary: A summary" in output
+    assert tool.name == "read_pages"
+    assert tool.description == "Read pages"
+
+
+def test_contents_reports_empty_and_failed_results():
+    exa = Exa("test")
+    exa.get_contents = lambda urls, **kwargs: response()
+    tool = exa.tools.get_contents()
+    assert tool.run({"urls": ["https://example.com"]}) == "No contents found."
+    assert "Error:" in tool.run({"urls": "not-a-list"})
+
+    exa.get_contents = lambda urls, **kwargs: (_ for _ in ()).throw(
+        ValueError("upstream")
+    )
+    assert tool.run({"urls": ["https://example.com"]}) == "Error: upstream"
+
+
+def test_contents_and_search_tools_coexist_across_providers():
+    exa = Exa("test")
+    exa.search = lambda query, **kwargs: response(result(highlights=["a fact"]))
+    exa.get_contents = lambda urls, **kwargs: response(result(text="Page text"))
+    exa.openai.web_search()
+    exa.openai.get_contents()
+
+    outputs = exa.openai.handle_tool_calls(
+        {
+            "tool_calls": [
+                {"id": "1", "function": {"name": "web_search", "arguments": '{"query":"q"}'}},
+                {
+                    "id": "2",
+                    "function": {
+                        "name": "get_contents",
+                        "arguments": '{"urls":["https://example.com"]}',
+                    },
+                },
+            ]
+        }
+    )
+    assert "a fact" in outputs[0]["content"]
+    assert "Text: Page text" in outputs[1]["content"]
+
+    responses_tool = exa.openai.responses.get_contents()
+    assert responses_tool["type"] == "function"
+    assert responses_tool["name"] == "get_contents"
+    assert responses_tool.definition == dict(responses_tool)
+
+    anthropic_tool = exa.anthropic.get_contents()
+    assert anthropic_tool == {
+        "name": "get_contents",
+        "description": anthropic_tool.description,
+        "input_schema": anthropic_tool.json_schema,
+    }
+    tool_results = exa.anthropic.handle_tool_use(
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "u",
+                    "name": "get_contents",
+                    "input": {"urls": ["https://example.com"]},
+                }
+            ]
+        }
+    )
+    assert "Text: Page text" in tool_results[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_async_contents_tools_and_handlers():
+    exa = AsyncExa("test")
+    seen = {}
+
+    async def get_contents(urls, **kwargs):
+        seen["urls"] = urls
+        return response(result(text="Page text"))
+
+    exa.get_contents = get_contents
+    tool = exa.openai.get_contents()
+    assert "Text: Page text" in await tool.run({"urls": ["https://example.com"]})
+    assert seen["urls"] == ["https://example.com"]
+
+    outputs = await exa.openai.handle_tool_calls(
+        {
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "function": {
+                        "name": "get_contents",
+                        "arguments": '{"urls":["https://example.com"]}',
+                    },
+                }
+            ]
+        }
+    )
+    assert "Text: Page text" in outputs[0]["content"]
+
+    responses_outputs = await exa.openai.responses.handle_tool_calls(
+        [
+            {
+                "type": "function_call",
+                "name": "get_contents",
+                "call_id": "c",
+                "arguments": '{"urls":["https://example.com"]}',
+            }
+        ]
+    )
+    assert "Text: Page text" in responses_outputs[0]["output"]
+
+    anthropic_tool = exa.anthropic.get_contents()
+    assert anthropic_tool["name"] == "get_contents"
+    tool_results = await exa.anthropic.handle_tool_use(
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "u",
+                    "name": "get_contents",
+                    "input": {"urls": ["https://example.com"]},
+                }
+            ]
+        }
+    )
+    assert "Text: Page text" in tool_results[0]["content"]


### PR DESCRIPTION
## Summary
Adds `get_contents` tool helpers alongside `web_search`, so agents can fetch pages when they already have URLs.

Available across sync + async:
- `exa.tools.get_contents()`
- `exa.openai.get_contents()`
- `exa.openai.responses.get_contents()`
- `exa.anthropic.get_contents()`

The model only gets `urls`. Everything else is bound by the developer when the tool is created, so the model can't change crawl/content behavior.

```python
exa.openai.get_contents(summary=True, livecrawl="preferred")
```

Also shares result formatting with search, including summaries and the existing `Highlights` → `Text` fallback.

Tests cover provider schemas, option forwarding, empty/error results, coexistence with `web_search`, async, and tool-call handlers. Tested against the prod `/contents` API before pushing.
